### PR TITLE
Added GitHub Dark Theme + Persistent Theme Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Package Frontend for the Pulsar Package Backend.",
   "main": "./src/server.js",
   "scripts": {

--- a/public/site.css
+++ b/public/site.css
@@ -14,11 +14,48 @@
   --footer-link-text-colour: #574c4f;
   --btn-bg-colour: #eee;
   --btn-border: 1px solid #d5d5d5;
+  --search-bar-bg-colour: white;
   font-family: "Helvetica Neue", Helvetica, arial, freesans, clean, sans-serif;
 }
 
 body[theme="original-theme"] {
+  --svg-stroke: #999;
+  --chip-background-colour: #d1d5db;
+  --card-border-colour: #ddd;
+  --card-meta-detail-colour: #fafafa;
+  --card-meta-box-colour: #fcfcfc;
+  --page-background-colour: white;
+  --page-text-colour: black;
+  --link-text-colour: #3b9b6d;
+  --card-meta-box-border-colour: #d5d5d5;
+  --header-background-colour: #584b4f;
+  --header-link-text-colour: #efeae1;
+  --footer-background-colour: #efeae1;
+  --footer-link-text-colour: #574c4f;
+  --btn-bg-colour: #eee;
+  --btn-border: 1px solid #d5d5d5;
+  --search-bar-bg-colour: white;
+  font-family: "Helvetica Neue", Helvetica, arial, freesans, clean, sans-serif;
+}
 
+body[theme="github-dark"] {
+  --svg-stroke: #8b949e;
+  --chip-background-colour: rgba(56,139,253,0.15);
+  --card-border-colour: #30363d;
+  --card-meta-detail-colour: #161b22;
+  --card-meta-box-colour: #21262d;
+  --page-background-colour: #0d1117;
+  --page-text-colour: #c9d1d9;
+  --link-text-colour: #58a6ff;
+  --card-meta-box-border-colour: rgba(240,246,252,0.1);
+  --header-background-colour: #161b22;
+  --header-link-text-colour: #f0f6fc;
+  --footer-background-colour: #161b22;
+  --footer-link-text-colour: #f0f6fc;
+  --btn-bg-colour: #21262d;
+  --btn-border: 1px solid rgba(240,246,252,0.1);
+  --search-bar-bg-colour: #0d1117;
+  font-family: "Helvetica Neue", Helvetica, arial, freesans, clean, sans-serif;
 }
 
 body {
@@ -257,6 +294,7 @@ a .package-install {
   padding: 0.75rem 0.375rem;
   border: var(--btn-border);
   border-radius: 0.375rem;
+  background-color: var(--search-bar-bg-colour);
 }
 
 .search-button {
@@ -269,6 +307,7 @@ a .package-install {
   background-color: var(--btn-bg-colour);
   padding: 0.75rem 0.375rem;
   border: var(--btn-border);
+  color: var(--page-text-colour);
 }
 
 .package-list-header {

--- a/public/site.js
+++ b/public/site.js
@@ -4,9 +4,15 @@ function changeThemeBtn() {
 
 function changeTheme(theme) {
   switch(theme) {
+    case "github-dark":
+      document.body.setAttribute("theme", "github-dark");
+      localStorage.setItem("theme", "github-dark");
+      break;
     case "original-theme":
     default:
       document.body.setAttribute("theme", "original-theme");
+      localStorage.setItem("theme", "original-theme");
+      break;
   }
 }
 
@@ -21,3 +27,10 @@ window.onclick = function(event) {
     }
   }
 }
+
+window.onload = function(event) {
+  if (localStorage.getItem("theme")) {
+    // If a theme has been set or saved.
+    changeTheme(localStorage.getItem("theme"));
+  }
+};

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -13,6 +13,7 @@ html(lang="en")
         button(onclick='changeThemeBtn()' class='dropbtn') Change Theme
         div(class='dropdown-content' id='dropdown-list')
           div(class='dropdown-item' onclick='changeTheme("original-theme")') Atom.io Theme
+          div(class='dropdown-item', onclick='changeTheme("github-dark")') GitHub Dark Theme
     block content
     footer
       div(class='footer')


### PR DESCRIPTION
Adds an additional theme "GitHub Dark Theme", obviously modeled after GitHub's native Dark Theme.

Additionally this adds support for persistent themes, storing the users choice in the browsers local storage and swapping on page load if needed.

Lastly, this bumps the version for tracking changes on the published site.

---

Preview of the new theme:

![image](https://user-images.githubusercontent.com/26921489/199661729-7bc63cd4-4a3b-425f-b5f8-99da6ed53518.png)
