### PR TITLE
Adds `timecop` capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ Currently `loadStats()` is unable to display how long certain actions took, whic
 
 * The time `ExpressJS` took to handle the request itself.
 * The time `PugJS`/`Jade` templates took to handle creating and displaying the page.
+
+---
+
+## Developers
+
+To run and test `package-frontend` locally should be rather simple.
+
+After cloning the repository, run `npm install` within the root of the folder.
+
+Then copy or rename `app.example.yaml` to `app.yaml`. When working with a local app config file you can change settings of the backend API to interact with to use a local version, or change the port the frontend is exposed on.
+
+Within the config file exists the key `GOOGLE_APPLICATION_CREDENTIALS` this key is used to point to a KeyFile containing Google Application Credentails to interact with Remote Caches. If you don't have access to this file set it to `"no-file"` like so:
+
+```yaml
+GOOGLE_APPLICATION_CREDENTIALS: "no-file"
+```
+
+This is a special value that will cause the caching service to automatically ignore any cache requests, and force request through to the backend service. Allowing to fail gracefully.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,41 @@ If you'd like to read about some of the challenges of normalizing the data acros
   * [Repository URLs](/docs/repository-urls.md)
   * [Authors](/docs/authors.md)
   * [Links](/docs/links.md)
+
+---
+
+When browsing the website, if you'd like to investigate what's caused the page load to take a long time there's now a built in utility to help determine that. While it can't show every aspect of the page load it could at least help to rule out some aspects.
+
+When on the website, open the DevTools for your respective browser and in the provided console type:
+
+```javascript
+loadStats();
+```
+
+This will output similar to the following:
+
+```json
+{
+  "api-request": {
+    "duration": 922.325,
+    "end": 2699.609,
+    "start": 1777.28
+  },
+  "transcribe-json": {
+    "duration": 14.55,
+    "end": 2714.175,
+    "start": 2699.617
+  }
+}
+```
+
+Of the above output, the only field that you should worry about is `duration`, as this tells you in milliseconds how long whatever action is related took. Of the actions that might be shown below is an explaination of what they mean.
+
+* `api-request`: An API Request was needed to be made to the backend server, and this shows the duration that request took.
+* `transcribe-json`: JSON Data received from an API request needs to be modified to be displayed to the end user, and some of these actions are intensive. This shows the duration it took to completly modify and return the JSON data.
+* `cache-check`: Local or Remote or Both types of caching are implemented on this endpoint. This shows the duration it took to check with said caches for the relevant data.
+
+Currently `loadStats()` is unable to display how long certain actions took, which are listed below:
+
+* The time `ExpressJS` took to handle the request itself.
+* The time `PugJS`/`Jade` templates took to handle creating and displaying the page.

--- a/app.example.yaml
+++ b/app.example.yaml
@@ -4,6 +4,6 @@ service: package-browser
 env_variables:
   PORT: 8080
   APIURL: "https://api.pulsar-edit.dev"
-  GOOGLE_APPLICATION_CREDENTIALS: "./key-file.json"
+  GOOGLE_APPLICATION_CREDENTIALS: "no-file"
   GCLOUD_STORAGE_BUCKET: "bucket-name"
   DEBUG: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-web",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Package Frontend for the Pulsar Package Backend.",
   "main": "./src/server.js",
   "scripts": {

--- a/public/site.js
+++ b/public/site.js
@@ -16,6 +16,14 @@ function changeTheme(theme) {
   }
 }
 
+function loadStats() {
+  if (timetable) {
+    console.log(timetable);
+  } else {
+    console.error("No stats found!");
+  }
+}
+
 window.onclick = function(event) {
   if (!event.target.matches('.dropbtn')) {
     let dropdowns = document.getElementsByClassName("dropdown-content");

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -8,15 +8,18 @@ async function statusPage(req, res) {
   res.render('status', { message: `Server is up and running ${server_version}` });
 }
 
-async function fullListingPage(req, res) {
+async function fullListingPage(req, res, timecop) {
+  timecop.start("api-request");
   superagent
     .get(`${apiurl}/api/packages`)
     .query(req.query)
     .then(ret => {
-
+      timecop.end("api-request");
+      timecop.start("transcribe-json");
       utils.prepareForListing(ret.body)
         .then(pack => {
-          res.render('package_list', { packages: pack });
+          timecop.end("transcribe-json");
+          res.render('package_list', { packages: pack, timecop: timecop.timetable });
         });
     })
     .catch(err => {
@@ -24,14 +27,18 @@ async function fullListingPage(req, res) {
     });
 }
 
-async function singlePackageListing(req, res) {
+async function singlePackageListing(req, res, timecop) {
+  timecop.start("api-request");
   superagent
     .get(`${apiurl}/api/packages/${decodeURIComponent(req.params.packageName)}`)
     .query(req.query)
     .then(ret => {
+      timecop.end("api-request");
+      timecop.start("transcribe-json");
       utils.prepareForDetail(ret.body)
         .then(pack => {
-          res.render('package_detail', { pack: pack });
+          timecop.end("transcribe-json");
+          res.render('package_detail', { pack: pack, timecop: timecop.timetable });
         });
     })
     .catch(err => {
@@ -39,14 +46,18 @@ async function singlePackageListing(req, res) {
     });
 }
 
-async function featuredPackageListing(req, res) {
+async function featuredPackageListing(req, res, timecop) {
+  timecop.start("api-request");
   superagent
     .get(`${apiurl}/api/packages/featured`)
     .query(req.query)
     .then(ret => {
+      timecop.end("api-request");
+      timecop.start("transcribe-json");
       utils.prepareForListing(ret.body)
         .then(pack => {
-          res.render('package_list', { packages: pack });
+          timecop.end("transcribe-json");
+          res.render('package_list', { packages: pack, timecop: timecop.timetable });
         });
     })
     .catch(err => {
@@ -54,21 +65,28 @@ async function featuredPackageListing(req, res) {
     });
 }
 
-async function homePage(req, res) {
+async function homePage(req, res, timecop) {
   // First lets check the cache
+  timecop.start("cache-check");
   let cached = await cache.getFeatured();
 
   if (cached !== null) {
+    timecop.end("cache-check");
     // We know our cache is good and lets serve the data
-    res.render('home', { featured: cached });
+    res.render('home', { featured: cached, timecop: timecop.timetable });
   } else {
     // the cache is invalid. We need to find the data, and cache it
+    timecop.end("cache-check");
+    timecop.start("api-request");
     superagent
       .get(`${apiurl}/api/packages/featured`)
       .then(ret => {
+        timecop.end("api-request");
+        timecop.start("transcribe-json");
         utils.prepareForListing(ret.body)
           .then(pack => {
-            res.render('home', { featured: pack });
+            timecop.end("transcribe-json");
+            res.render('home', { featured: pack, timecop: timecop.timetable });
             // then set featured cache
             cache.setFeatured(pack);
           });
@@ -76,14 +94,18 @@ async function homePage(req, res) {
   }
 }
 
-async function searchHandler(req, res) {
+async function searchHandler(req, res, timecop) {
+  timecop.start("api-request");
   superagent
     .get(`${apiurl}/api/packages/search`)
     .query(req.query)
     .then(ret => {
+      timecop.end("api-request");
+      timecop.start("transcribe-json");
       utils.prepareForListing(ret.body)
         .then(pack => {
-          res.render('search', { packages: pack, search: req.query.q });
+          timecop.end("transcribe-json");
+          res.render('search', { packages: pack, search: req.query.q, timecop: timecop.timetable });
         });
     })
     .catch(err => {

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,8 @@ app.use((req, res, next) => {
 app.use("/public", express.static("./public"));
 
 app.get("/", async (req, res) => {
-  await handlers.homePage(req, res);
+  let timecop = new utils.Timecop();
+  await handlers.homePage(req, res, timecop);
 });
 
 app.get("/status", async (req, res) => {
@@ -23,22 +24,26 @@ app.get("/status", async (req, res) => {
 
 app.get("/packages", async (req, res) => {
   // the main package listing
-  await handlers.fullListingPage(req, res);
+  let timecop = new utils.Timecop();
+  await handlers.fullListingPage(req, res, timecop);
 });
 
 app.get("/packages/featured", async (req, res) => {
   // view list of featured packages
-  await handlers.featuredPackageListing(req, res);
+  let timecop = new utils.Timecop();
+  await handlers.featuredPackageListing(req, res, timecop);
 });
 
 app.get("/packages/search", async (req, res) => {
   // execute a search for packages
-  await handlers.searchHandler(req, res);
+  let timecop = new utils.Timecop();
+  await handlers.searchHandler(req, res, timecop);
 });
 
 app.get("/packages/:packageName", async (req, res) => {
   // view details of a package
-  await handlers.singlePackageListing(req, res);
+  let timecop = new utils.Timecop();
+  await handlers.singlePackageListing(req, res, timecop);
 });
 
 // Static specfic files to send.

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,6 @@ let md = new MarkdownIt({
 });
 
 const reg = require("./reg.js");
-const { performance } = require("node:perf_hooks");
 
 // Collection of utility functions for the frontend
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,7 @@ let md = new MarkdownIt({
 });
 
 const reg = require("./reg.js");
+const { performance } = require("node:perf_hooks");
 
 // Collection of utility functions for the frontend
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,8 +181,29 @@ function findRepoField(obj) {
 
 }
 
+class Timecop {
+  constructor() {
+    this.timetable = {};
+  }
+  start(service) {
+    this.timetable[service] = {
+      start: performance.now(),
+      end: undefined,
+      duration: undefined
+    }
+  }
+
+  end(service) {
+    this.timetable[service].end = performance.now();
+    this.timetable[service].duration =
+      this.timetable[service].end -
+      this.timetable[service].start;
+  }
+}
+
 module.exports = {
   displayError,
   prepareForListing,
   prepareForDetail,
+  Timecop,
 };

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -5,6 +5,9 @@ html(lang="en")
     link(rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/default.min.css")
     block header
   body
+    if timecop
+      script.
+        let timetable = !{JSON.stringify(timecop)};
     div(class='header')
       a(href='https://pulsar-edit.dev') Website
       a(href='/') Package Home


### PR DESCRIPTION
This PR adds a new feature to the website called `timecop`, the naming borrowed from the internal `timecop` tool of the Pulsar Editor.

As we continue to investigate what causes long loading times of the website, `timecop` allows end users and us to investigate what takes the time of our page loads. 

Once a page is loaded within the browsers DevTools Console a user can run `loadStats()` and get some output of the page load times internally, such as how long API Requests took, and how long it took to transcribe JSON data, or the time taken to check Local/Remote Caches for data.

Ideally this can be used in future debugging and issue templates.