### PR TITLE
Add repo links and details to bar

### DIFF
--- a/public/site.css
+++ b/public/site.css
@@ -269,6 +269,19 @@ a .package-install {
   padding-bottom: 40px;
 }
 
+.package-btn-links, .package-btn-group {
+  display:flex;
+  align-items:center;
+}
+
+.package-btn-links {
+  gap: 10px;
+}
+
+.package-btn-group {
+  gap: 3px
+}
+
 .search-bar-container {
   width: 75%;
   height: 100%;

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,7 @@ function prepareForDetail(obj) {
     pack.license = obj.metadata.license ? obj.metadata.license : "";
     pack.version = obj.metadata.version ? obj.metadata.version : "";
     pack.repoLink = findRepoField(obj);
+    pack.bugLink = obj.metadata.bugs ? obj.metadata.bugs.url : "";
     pack.install = `atom://settings-view/show-package?package=${pack.name}`;
 
     // Add custom handling of image links. This aims to fix the common issue of users specifying local paths in their links.

--- a/views/package_detail.pug
+++ b/views/package_detail.pug
@@ -9,18 +9,27 @@ block content
       include package_listing
   div(class='package-fullpage-details')
     div(class='package-btn-links')
-      a(href='repo')
+      a(class='package-btn-group' href=pack.repoLink)
         svg(class="icon")
           use(href="/public/feather-sprite.svg#book")
-      a(href='bugs')
-        svg(class="icon")
-          use(href="/public/feather-sprite.svg#alert-circle")
-      a(href='version')
+        span.
+          GitHub
+      if pack.bugLink
+        a(class='package-btn-group' href=pack.bugLink)
+          svg(class="icon")
+            use(href="/public/feather-sprite.svg#alert-circle")
+          span.
+            Bug Reports
+      div(class='package-btn-group')
         svg(class="icon")
           use(href="/public/feather-sprite.svg#tag")
-      a(href='license')
+        span.
+          #{pack.version}
+      div(class='package-btn-group')
         svg(class="icon")
           use(href="/public/feather-sprite.svg#flag")
+        span.
+          #{pack.license}
     div(class='package-readme')
       .
         !{pack.readme}


### PR DESCRIPTION
This PR edits and updates the button bar on the package detail view.

- New value for the `pack` object which assigns `bugs.url` if present
- RepoLink now applies to the icon and new text "GitHub"
- BugLink applies to the icon and new text "Bug Reports"
- The Version and Licence metadata now display next to their respective items but do not link anywhere
- New class added so the elements can be properly "grouped" for CSS.
- New CSS elements added to style the bar as a flexbox and space the grouped items correctly.

Example page with bugs.url metadata:
![image](https://user-images.githubusercontent.com/58074586/202930649-dfadb323-37b4-409c-818d-4f1b1d3c2860.png)

Without:
![image](https://user-images.githubusercontent.com/58074586/202930664-89c376ba-725f-4a68-88c9-48b9fc6ddb90.png)
