### PR TITLE
Use Absolute Paths for `res.sendFile()`

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const app = express();
+const path = require("path");
 const handlers = require("./handlers.js");
 const utils = require("./utils.js");
 
@@ -49,11 +50,11 @@ app.get("/packages/:packageName", async (req, res) => {
 // Static specfic files to send.
 
 app.get("/robots.txt", (req, res) => {
-  res.sendFile("./static/robots.txt");
+  res.sendFile(path.resolve("./static/robots.txt"));
 });
 
 app.get("/sitemap.xml", (req, res) => {
-  res.sendFile("./static/sitemap.xml");
+  res.sendFile(path.resolve("./static/sitemap.xml"));
 });
 
 app.use(async (req, res) => {


### PR DESCRIPTION
Currently any automated requests to `robots.txt` and `sitemap.xml` are failing, since we are passing relative paths to `res.sendFile()` which [requires](https://expressjs.com/en/4x/api.html#res.sendFile) use of an absolute path. Merging this should resolve those errors.