### PR TITLE
Dev Mode - Social Card Editing - Download Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ If you'd like to read about some of the challenges of normalizing the data acros
   * [Authors](/docs/authors.md)
   * [Links](/docs/links.md)
 
+Additionally for anyone crafting a direct download link to our Pulsar Binaries from Cirrus CI:
+  * [Download Link Table](/docs/download_links.md)
+
 ---
 
 When browsing the website, if you'd like to investigate what's caused the page load to take a long time there's now a built in utility to help determine that. While it can't show every aspect of the page load it could at least help to rule out some aspects.
@@ -69,6 +72,12 @@ GOOGLE_APPLICATION_CREDENTIALS: "no-file"
 ```
 
 This is a special value that will cause the caching service to automatically ignore any cache requests, and force request through to the backend service. Allowing to fail gracefully.
+
+### Running In Dev Mode
+
+Using `npm run start:dev` you can run the Package Frontend Server in Development mode. This does two notable things:
+  - Disables Remote Cache Features Natively. Setting `GOOGLE_APPLICATION_CREDENTIALS: "no-file"` is not necessary when run in dev mode.
+  - Exposes a secret API endpoint. `/dev/image/packages/:packageName` will be available when in dev mode, and gives direct access to the HTML code used to display the Social Cards. Using this can allow easier modification and editing of our Social Cards.
 
 ### Creating a new Social Card
 

--- a/docs/download_links.md
+++ b/docs/download_links.md
@@ -35,6 +35,8 @@ All `type` Options:
 - `linux_rpm`
 - `linux_deb`
 
+Example: https://web.pulsar-edit.dev/download?os=windows&type=windows_portable
+
 Full Table:
 
 | Binary Name | Query `os` Value | Query `type` Value |

--- a/docs/download_links.md
+++ b/docs/download_links.md
@@ -1,0 +1,60 @@
+# Download Links
+
+This repo also serves the vital purpose of handling download redirects.
+
+Currently we build on every push to `master` for `pulsar`. Each new run on Cirrus CI results in a binary application for many different operating systems and their variances.
+
+In order to allow users to install these easily the `https://web.pulsar-edit.dev/download` URL can redirect to any one of our binaries through a simple link and simple query parameters.
+
+To configure a link to properly point a user in the right direction take a look at the content below:
+
+---
+
+URL: https://web.pulsar-edit.dev/download
+Query Parameters: `os` && `type`
+
+All `os` Options:
+
+- `windows`
+- `intel_mac`
+- `silicon_mac`
+- `linux`
+- `arm_linux`
+
+All `type` Options:
+
+- `windows_setup`
+- `windows_portable`
+- `windows_blockmap`
+- `mac_zip`
+- `mac_zip_blockmap`
+- `mac_dmg`
+- `mac_dmg_blockmap`
+- `linux_appimage`
+- `linux_tar`
+- `linux_rpm`
+- `linux_deb`
+
+Full Table:
+
+| Binary Name | Query `os` Value | Query `type` Value |
+| ---         | ---              | ---                |
+| Pulsar 1.63.2022120100.exe | `windows` | `windows_portable` |
+| Pulsar Setup 1.63.2022120100.exe | `windows` | `windows_setup` |
+| Pulsar Setup 1.63.2022120100.exe.blockmap | `windows` | `windows_blockmap` |
+| Pulsar-1.63.2022120100-mac.zip | `intel_mac` | `mac_zip` |
+| Pulsar-1.63.2022120100-mac.zip.blockmap | `intel_mac` | `mac_zip_blockmap` |
+| Pulsar-1.63.2022120100.dmg | `intel_mac` | `mac_dmg` |
+| Pulsar-1.63.2022120100.dmg.blockmap | `intel_mac` | `mac_dmg_blockmap` |
+| Pulsar-1.63.2022120100-arm64-mac.zip | `silicon_mac` | `mac_zip` |
+| Pulsar-1.63.2022120100-arm64-mac.zip.blockmap | `silicon_mac` | `mac_zip_blockmap` |
+| Pulsar-1.63.2022120100-arm64.dmg | `silicon_mac` | `mac_dmg` |
+| Pulsar-1.63.2022120100-arm64.dmg.blockmap | `silicon_mac` | `mac_dmg_blockmap` |
+| Pulsar-1.63.2022120100-arm64.AppImage | `arm_linux` | `linux_appimage` |
+| pulsar-1.63.2022120100-arm64.tar.gz | `arm_linux` | `linux_tar` |
+| pulsar-1.63.2022120100.aarch64.rpm | `arm_linux` | `linux_rpm` |
+| pulsar_1.63.2022120100_arm64.deb | `arm_linux` | `linux_deb` |
+| Pulsar-1.63.2022120100.AppImage | `linux` | `linux_appimage` |
+| pulsar-1.63.2022120100.tar.gz | `linux` | `linux_tar` |
+| pulsar-1.63.2022120100.x86_64.rpm | `linux` | `linux_rpm` |
+| pulsar_1.63.2022120100_amd64.deb | `linux` | `linux_deb` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "package-web",
       "version": "1.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^6.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "superagent": "^8.0.1"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "jest": "^29.2.2"
       }
     },
@@ -1955,6 +1956,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {
@@ -7089,6 +7108,15 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node ./src/server.js",
     "test": "jest ./src/tests/",
-    "postinatall": "node node_modules/puppeteer/install.js",
+    "postinstall": "node node_modules/puppeteer/install.js",
+    "start:dev": "cross-env PULSAR_STATUS=dev node ./src/server.js",
     "deploy_script": "echo 'Do not run!' && gcloud app deploy --no-cache"
   },
   "author": "confused-Techie",
@@ -24,6 +25,7 @@
     "superagent": "^8.0.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "jest": "^29.2.2"
   }
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -24,7 +24,7 @@ async function getFeatured() {
     return local_cache.featured;
 
   } else {
-    if (GOOGLE_APPLICATION_CREDENTIALS == "no-file") {
+    if (GOOGLE_APPLICATION_CREDENTIALS == "no-file" || process.env.PULSAR_STATUS === "dev") {
       // Having this set as no-file is a supported way to fail gracefully on cache checks.
       return null;
     } else {

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -60,6 +60,21 @@ async function packageImage(req, res) {
   }
 }
 
+async function devPackageImage(req, res) {
+  if (process.env.PULSAR_STATUS === "dev") {
+    try {
+      let api = await superagent.get(`${apiurl}/api/packages/${decodeURIComponent(req.params.packageName)}`).query(req.query);
+      let page = await utils.generateImageHTML(api.body, "default");
+      res.send(page);
+    } catch(err) {
+      console.log(err);
+      utils.displayError(req, res, err);
+    }
+  } else {
+    res.status(503).json({ message: "This service is only available during Development Runtime" });
+  }
+}
+
 async function featuredPackageListing(req, res, timecop) {
   timecop.start("api-request");
   try {
@@ -144,4 +159,5 @@ module.exports = {
   singlePackageListing,
   featuredPackageListing,
   packageImage,
+  devPackageImage,
 };

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -151,6 +151,197 @@ async function searchHandler(req, res, timecop) {
   }
 }
 
+async function downloadLink(req, res) {
+  let params = {
+    os: req.query.os ?? "",
+    type: req.query.type ?? ""
+  };
+
+  if (params.os === "" || params.type === "") {
+    res.status(503).json({ message: "Invalid Download Parameters provided." });
+    return;
+  }
+
+  try {
+
+    let baseQuery = `
+      query GetLatestBuildID {
+        ownerRepository(platform: "github", owner: "pulsar-edit", name: "pulsar") {
+          id
+          platform
+          owner
+          name
+          masterBranch
+          lastDefaultBranchBuild {
+            id
+          }
+        }
+      }
+    `;
+
+    let baseGraph = await superagent.post("https://api.cirrus-ci.com/graphql")
+                          .set("Content-Type", "application/json").set("Accept", "application/json")
+                          .send({ query: baseQuery });
+
+    let baseResponse = baseGraph.body;
+
+    let buildQuery = `
+      query GetTasksFromBuild {
+        build(id: "${baseResponse.data.ownerRepository.lastDefaultBranchBuild.id}") {
+          status
+          tasks {
+            name
+            id
+          }
+        }
+      }
+    `;
+
+    let buildGraph = await superagent.post("https://api.cirrus-ci.com/graphql")
+                            .set("Content-Type", "application/json").set("Accept", "application/json")
+                            .send({ query: buildQuery });
+
+    let buildResponse = buildGraph.body;
+
+    let taskid = undefined;
+
+    const findID = function (name, builds) {
+      for (let i = 0; i < builds.length; i++) {
+        if (builds[i].name == name) {
+          return builds[i].id;
+        }
+      }
+      return undefined;
+    };
+
+    // While it seems to make total sense to just run `findID(params.os, buildResponse.data.build.tasks)`
+    // The reason this was done, so that if these names change at all or more are added, the bulk
+    // of responsibility to update will lie soley here. Rather than let possible external links fail and expire.
+    // Such as `linux` changing to `Linux`, would only have to be done here rather than every location the link appears.
+    switch(params.os) {
+      case "linux":
+        taskid = findID("linux", buildResponse.data.build.tasks);
+        break;
+      case "arm_linux":
+        taskid = findID("arm_linux", buildResponse.data.build.tasks);
+        break;
+      case "silicon_mac":
+        taskid = findID("silicon_mac", buildResponse.data.build.tasks);
+        break;
+      case "intel_mac":
+        taskid = findID("intel_mac", buildResponse.data.build.tasks);
+        break;
+      case "windows":
+        taskid = findID("windows", buildResponse.data.build.tasks);
+        break;
+      default:
+        taskid = undefined;
+        break;
+    }
+
+    if (taskid === undefined) {
+      res.status(503).json({ message: "Invalid Download Parameters provided." });
+      return;
+    }
+
+    let taskQuery = `
+      query GetTaskDetails {
+        task(id: ${taskid}) {
+          name
+          status
+          artifacts {
+            name
+            type
+            format
+            files {
+              path
+              size
+            }
+          }
+        }
+      }
+    `;
+
+    let taskGraph = await superagent.post("https://api.cirrus-ci.com/graphql")
+                          .set("Content-Type", "application/json").set("Accept", "application/json")
+                          .send({ query: taskQuery });
+
+    let binaryPath = undefined;
+
+    const findBinary = function (ext, loc, binaries) {
+      for (let i = 0; i < binaries.length; i++) {
+        if (loc === "start") {
+          if (binaries[i].path.startsWith(ext)) {
+            return binaries[i].path;
+          }
+        } else if (loc === "end") {
+          if (binaries[i].path.endsWith(ext)) {
+            return binaries[i].path;
+          }
+        }
+      }
+      return undefined;
+    };
+
+    switch(params.type) {
+      // Linux Binaries
+      case "linux_appimage":
+        binaryPath = findBinary(".AppImage", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "linux_tar":
+        binaryPath = findBinary(".tar.gz", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "linux_rpm":
+        binaryPath = findBinary(".rpm", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "linux_deb":
+        binaryPath = findBinary(".deb", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      // Windows Binaries
+      case "windows_setup":
+        binaryPath = findBinary("binaries/Pulsar Setup", "start", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "windows_portable":
+        binaryPath = findBinary(".exe", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "windows_blockmap":
+        binaryPath = findBinary(".exe.blockmap", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      // MacOS Builds
+      case "mac_zip":
+        binaryPath = findBinary(".zip", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "mac_zip_blockmap":
+        binaryPath = findBinary(".zip.blockmap", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "mac_dmg":
+        binaryPath = findBinary(".dmg", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      case "mac_dmg_blockmap":
+        binaryPath = findBinary(".dmb.blockmap", "end", taskGraph.body.data.task.artifacts[0].files);
+        break;
+      default:
+        binaryPath = undefined;
+        break;
+    }
+
+    if (binaryPath === undefined) {
+      res.status(503).json({ message: "Invalid Download Parameters provided." });
+      return;
+    }
+
+    // Now that we have the binary, it's time to return a redirect.
+
+    res.status(302).redirect(`https://api.cirrus-ci.com/v1/artifact/task/${taskid}/binary/${binaryPath}`);
+
+  } catch(err) {
+    console.log(err);
+    utils.displayError(req, res, err);
+  }
+
+
+}
+
 module.exports = {
   statusPage,
   homePage,
@@ -160,4 +351,5 @@ module.exports = {
   featuredPackageListing,
   packageImage,
   devPackageImage,
+  downloadLink
 };

--- a/src/image-templates/default/template.css
+++ b/src/image-templates/default/template.css
@@ -1,41 +1,28 @@
 .container {
-padding: 30px;
+padding: 20px 30px 30px 30px;
 margin: 20px;
-width: 80%;
 height: 80%;
 align-content: center;
 }
 
-.icon {
-stroke: black;
-width: 24px;
-height: 24px;
-stroke-width: 2;
-}
-
 .heading {
 font-weight: 600;
-font-size: 100px;
+font-size: 90px;
 display: flex;
 }
 
 .title {
 color: black;
-margin-right: 400px;
 font-family: 'Jura', sans-serif;
-padding-top: 10px;
 padding-bottom: 30px;
-}
-
-.author {
-padding-left: 5px;
-color: grey;
-font-size: 90px;
+white-space:nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
 }
 
 .subtitle {
 font-weight: 400;
-font-size: 40px;
+font-size: 35px;
 display: flex;
 padding-bottom: 5px;
 }
@@ -56,21 +43,26 @@ font-family: 'Jura', sans-serif;
 .description {
 padding-top: 15px;
 color: black;
-font-size: 50px;
+font-size: 40px;
 font-family: 'Jura', sans-serif;
+width: 920px;
+height: 250px;
+overflow: hidden;
 }
 
 .bottom-icons {
 display: inline-block;
-padding-top: 50px;
-padding-left: 5px;
-width: 100%;
+padding: 50px 0px 15px 5px;
 text-align: justify;
 font-size: 40px;
 font-family: 'Jura', sans-serif;
 position: absolute;
 bottom: 20px;
 left: 30px;
+}
+
+.bottom-icons > div > svg {
+  vertical-align: bottom;
 }
 
 .downloads {
@@ -107,6 +99,6 @@ color: grey;
 
 .pulsar-logo {
   position: absolute;
-  right: 80px;
-  bottom: 20px;
+  left: 940px;
+  bottom: 15px;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -58,7 +58,7 @@ app.get("/dev/image/packages/:packageName", async (req, res) => {
 });
 
 app.get("/download", async (req, res) => {
-
+  await handlers.downloadLink(req, res);
 });
 
 app.use(async (req, res) => {

--- a/src/main.js
+++ b/src/main.js
@@ -53,19 +53,13 @@ app.get("/image/packages/:packageName", async (req, res) => {
   await handlers.packageImage(req, res);
 });
 
-// Static specfic files to send.
+app.get("/dev/image/packages/:packageName", async (req, res) => {
+  await handlers.devPackageImage(req, res);
+});
 
-//app.get("/robots.txt", (req, res) => {/
-//  res.sendFile(path.resolve("./static/robots.txt"));
-//});
+app.get("/download", async (req, res) => {
 
-//app.get("/sitemap.xml", (req, res) => {
-//  res.sendFile(path.resolve("./static/sitemap.xml"));
-//});
-
-//app.get("/favicon.svg", (req, res) => {
-//  res.sendFile(path.resolve("./static/favicon.svg"));
-//});
+});
 
 app.use(async (req, res) => {
   // 404 here, keep at last position

--- a/src/utils.js
+++ b/src/utils.js
@@ -284,4 +284,5 @@ module.exports = {
   prepareForDetail,
   Timecop,
   generateImage,
+  generateImageHTML
 };


### PR DESCRIPTION
This PR touches on a few different areas that we are needing for further development.

- Dev Mode: Using `npm run start:dev` can now startup the server in dev mode. Further details in the PR readme.
- Social Card Editing: When in dev mode the new API Endpoint `/dev/image/packages/:packageName` is now exposed to allow contributors to edit and view the raw HTML that creates our social cards.
- Download Links: The new API Endpoint `/download` allows easy linking to our Cirrus CI binaries. Using this endpoint and it's two query parameters you can easily link to the most recent Cirrus CI build available. Further details on the query parameters and how to craft a link for this endpoint are in the `/docs/download_links.md` file.

Please feel free to ask for any clarifications on this PR. Thanks!