### PR TITLE
Tweak CSS for image

### DIFF
--- a/src/image-templates/default/template.css
+++ b/src/image-templates/default/template.css
@@ -1,41 +1,25 @@
 .container {
-padding: 30px;
+padding: 20px 30px 30px 30px;
 margin: 20px;
-width: 80%;
 height: 80%;
 align-content: center;
 }
 
-.icon {
-stroke: black;
-width: 24px;
-height: 24px;
-stroke-width: 2;
-}
-
 .heading {
 font-weight: 600;
-font-size: 100px;
+font-size: 90px;
 display: flex;
 }
 
 .title {
 color: black;
-margin-right: 400px;
 font-family: 'Jura', sans-serif;
-padding-top: 10px;
 padding-bottom: 30px;
-}
-
-.author {
-padding-left: 5px;
-color: grey;
-font-size: 90px;
 }
 
 .subtitle {
 font-weight: 400;
-font-size: 40px;
+font-size: 35px;
 display: flex;
 padding-bottom: 5px;
 }
@@ -56,21 +40,24 @@ font-family: 'Jura', sans-serif;
 .description {
 padding-top: 15px;
 color: black;
-font-size: 50px;
+font-size: 40px;
 font-family: 'Jura', sans-serif;
+width: 920px;
 }
 
 .bottom-icons {
 display: inline-block;
-padding-top: 50px;
-padding-left: 5px;
-width: 100%;
+padding: 50px 0px 15px 5px;
 text-align: justify;
 font-size: 40px;
 font-family: 'Jura', sans-serif;
 position: absolute;
 bottom: 20px;
 left: 30px;
+}
+
+.bottom-icons > div > svg {
+  vertical-align: bottom;
 }
 
 .downloads {
@@ -107,6 +94,6 @@ color: grey;
 
 .pulsar-logo {
   position: absolute;
-  right: 80px;
-  bottom: 20px;
+  left: 940px;
+  bottom: 15px;
 }

--- a/src/image-templates/default/template.css
+++ b/src/image-templates/default/template.css
@@ -43,6 +43,9 @@ color: black;
 font-size: 40px;
 font-family: 'Jura', sans-serif;
 width: 920px;
+height: 250px;
+overflow: hidden;
+text-overflow: ellipsis;
 }
 
 .bottom-icons {

--- a/src/image-templates/default/template.css
+++ b/src/image-templates/default/template.css
@@ -15,6 +15,9 @@ display: flex;
 color: black;
 font-family: 'Jura', sans-serif;
 padding-bottom: 30px;
+white-space:nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
 }
 
 .subtitle {
@@ -45,7 +48,6 @@ font-family: 'Jura', sans-serif;
 width: 920px;
 height: 250px;
 overflow: hidden;
-text-overflow: ellipsis;
 }
 
 .bottom-icons {


### PR DESCRIPTION
So there are a bunch of minor changes to the CSS as you can see which I think resolve a couple of issues.

I've also removed some redundant selectors, if we want to add any of these pack in later with the inclusion of icons or something then it shouldn't be too difficult.

The major changes I've made here are:
- Slight reduction of borders to reduce some of the whitespace a tiny bit, particularly at the top with the header
- Remove `width` attributes from .container, .heading and .bottom-icons as with the margins they were causing an overflow - on the .heading this allows longer package titles with no wrapping, even some fairly short names were wrapping to a second line.
- Scale the font sizes down a tiny bit to allow for longer descriptions and titles without wrapping
- Re-do the absolute positioning for the pulsar logo so it aligns on the baseline
- Add a new selector for the svg icons in the bottom icons so they align correctly with the text
- Remove .author and .icon as these aren't currently used.
- Enforce single line with overflow on title - we should really scale the font-size attribute automatically somehow here - might need somebody smarter than me to do this. Might also need to do this with .link.
- Added a size to the description box with a hidden overflow

Before:
![image](https://user-images.githubusercontent.com/58074586/205452009-eebed0bc-8515-4bb9-addf-e5e8fafda251.png)

After:
![image](https://user-images.githubusercontent.com/58074586/205452075-aabbd6c4-0787-4116-821c-88e664dfcc2a.png)

With a long title and description:

Before:
![image](https://user-images.githubusercontent.com/58074586/205451982-5ee1653d-4e08-4661-8920-a22ef7c4d0d9.png)

After:
![image](https://user-images.githubusercontent.com/58074586/205455171-4a374246-295b-4091-92e4-dbcbafda7b3d.png)
