### PR TITLE
[FEAT] "Log Out" and "My Account" buttons in header

### DIFF
--- a/ejs-views/logout.ejs
+++ b/ejs-views/logout.ejs
@@ -1,0 +1,4 @@
+<script>
+    localStorage.removeItem('user');
+    window.location.replace("/");
+</script>

--- a/public/site.js
+++ b/public/site.js
@@ -63,6 +63,9 @@ window.onload = function (event) {
     changeTheme(localStorage.getItem("theme"));
   }
 
+  // Add the header links if we are logged in
+  if (isLoggedIn()) { modifyNavigation(); }
+    
   // Check to see if we are on the User Account Page
   if (window.location.href.startsWith("https://web.pulsar-edit.dev/users")) {
   //if (window.location.href.indexOf("/users")) {
@@ -102,6 +105,10 @@ function userAccountActions() {
     // The user needs to access the API to retreive user details. Ignore any local data.
     userAccountAPI(token);
   }
+}
+
+function isLoggedIn() {
+  return !!localStorage.getItem("user");
 }
 
 function userAccountLocal() {
@@ -178,4 +185,23 @@ function modifyUserPage(user) {
 
   // Modify Token
   tokenBox.value = user.token;
+}
+
+function modifyNavigation() {
+  // Obtain references to the header
+  const header = document.querySelector(".header");
+  const headerLinks = document.querySelectorAll('.header > a');
+
+  // Set the "log in" link to now be "log out"
+  const loginLink = Array.from(headerLinks).find(i => i.href === `${document.location.origin}/login`);
+  loginLink.innerHTML = 'Log Out';
+  loginLink.href = '/logout';
+
+  // Create a new button to go to their account
+  const accountLink = document.createElement("a");
+  accountLink.href = '/users';
+  accountLink.innerHTML = 'My Account';
+
+  // Insert the button before the "log out" button
+  header.insertBefore(accountLink, loginLink);
 }

--- a/public/site.js
+++ b/public/site.js
@@ -112,7 +112,7 @@ function isLoggedIn() {
 }
 
 function userAccountLocal() {
-  if (localStorage.getItem("user")) {
+  if (isLoggedIn()) {
     let user = localStorage.getItem("user");
 
     user = JSON.parse(user);

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -366,6 +366,17 @@ async function loginHandler(req, res, timecop) {
   }});
 }
 
+async function logoutHandler(req, res, timecop) {
+  // This is a very simple return with no api, so we will just render
+  res.render("logout", { timecop: timecop.timetable, page: {
+    name: "Pulsar Logout",
+    og_url: "https://web.pulsar-edit.dev/logout",
+    og_description: "The Pulsar Log Out Page",
+    og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+    og_image_type: "image/svg+xml"
+  }});
+}
+
 async function userPageHandler(req, res, timecop) {
   // This is the signed in user page.
   // Since we will let the JavaScript on the page handle any API call needed here lets just
@@ -390,5 +401,6 @@ module.exports = {
   devPackageImage,
   downloadLink,
   loginHandler,
+  logoutHandler,
   userPageHandler,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,12 @@ app.get("/login", async (req, res) => {
   await handlers.loginHandler(req, res, timecop);
 });
 
+app.get("/logout", async (req, res) => {
+  // The Login/Sign Up Page showing all sign in options
+  let timecop = new utils.Timecop();
+  await handlers.logoutHandler(req, res, timecop);
+});
+
 app.get("/image/packages/:packageName", async (req, res) => {
   await handlers.packageImage(req, res);
 });


### PR DESCRIPTION
# Summary

It's a bit of a continuity issue to be actively logged in but still have a log in button in the header. This PR does a couple things:

- ✨ Adds in a `/logout` route that will remove the localStorage `user` item and take them back to the home page
- ✨ Adds a new `isLoggedIn()` function to check if the user is currently logged in
- ✨ Adds a "Log Out" button to the navigation bar that replaces the "Log In" when the user is logged in
- ✨ Adds a "My Account" button before the "Log Out" button when the user is logged in

# Showcase

<img width="100%" src="https://user-images.githubusercontent.com/6710794/208136633-69bb9df7-e9fd-43e3-925f-7d9752b7732e.png">
