### PR TITLE
[BUG] Subtext has low contrast on dark themes

### DIFF
--- a/ejs-views/partials/footer.ejs
+++ b/ejs-views/partials/footer.ejs
@@ -28,7 +28,7 @@
             <a href="https://pulsar-edit.dev/community.html" target="_blank">Contact Us</a>
         </div>
     </div>
-    <p class="text-sm text-gray-600">Pulsar-Edit © <%- new Date().getFullYear() %></p>
+    <p class="text-sm opacity-70">Pulsar-Edit © <%- new Date().getFullYear() %></p>
 </footer>
 </body>
 <script src="/public/site.js"></script>

--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -1,6 +1,6 @@
 <div class="w-full border border-secondary rounded p-3">
   <a href="/packages/<%=pack.name%>" class="text-3xl text-primary"><%=pack.name%></a>
-  <p class="text-sm text-gray-600 min-h-[80px] py-3"><%=pack.description%></p>
+  <p class="text-sm opacity-70 min-h-[80px] py-3"><%=pack.description%></p>
   <div class="md:flex sm:flex-col md:flex-row gap-3">
     <div class="md:flex items-center justify-between bg-secondary p-3 rounded flex-1">
       <p class="flex items-center">

--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,6 +1,6 @@
 <% if (locals.pagination) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
-        <p class="text-gray-600">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
+        <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
         <div class="flex items-center sm:gap-6 gap-3">
             <a href="<%- pagination.routes.first %>" class="<%- !!pagination.routes.first ? '' : 'disabled' %>">
                 <i class="fas fa-chevron-left -mr-1"></i>

--- a/src/site.css
+++ b/src/site.css
@@ -64,7 +64,7 @@ article button {
 }
 
 footer h2 {
-  @apply text-gray-600 mb-3;
+  @apply opacity-70 mb-3;
 }
 
 footer i {
@@ -121,7 +121,7 @@ nav.active {
 /**************************/
 
 #pagination a {
-  @apply text-gray-600 flex items-center justify-center rounded-full font-light w-7 h-7 hover:bg-secondary;
+  @apply opacity-70 flex items-center justify-center rounded-full font-light w-7 h-7 hover:bg-secondary;
 }
 
 #pagination a.active {


### PR DESCRIPTION
# Summary

Fixes #38 

Subtext is difficult to read when on dark themes. This changes the "subtext" colors to just be muted versions of the primary text color, which in this case makes it a grey-ish color when it blends with the black background.

# Showcase

| Before      | After |
| ----------- | ----------- |
| <img width="485" alt="Screenshot 2022-12-29 at 9 52 36 AM" src="https://user-images.githubusercontent.com/6710794/209978035-772b70e5-b9c4-4876-b92d-d8d61d3aa133.png"> |  <img width="488" alt="Screenshot 2022-12-29 at 9 51 26 AM" src="https://user-images.githubusercontent.com/6710794/209978260-2b2b0652-289b-4daa-a17a-d8535630edb4.png"> |
| <img width="484" alt="Screenshot 2022-12-29 at 9 52 47 AM" src="https://user-images.githubusercontent.com/6710794/209978061-3df11623-1761-43a1-a13e-bdc4c9909db2.png"> |  <img width="489" alt="Screenshot 2022-12-29 at 9 51 36 AM" src="https://user-images.githubusercontent.com/6710794/209978300-d5967d03-9932-49c2-91ec-e30685c0cf3a.png"> |   
| <img width="484" alt="Screenshot 2022-12-29 at 9 52 52 AM" src="https://user-images.githubusercontent.com/6710794/209978125-abe271eb-5267-4879-9ccc-f7527a3dada7.png"> |  <img width="491" alt="Screenshot 2022-12-29 at 9 51 43 AM" src="https://user-images.githubusercontent.com/6710794/209978324-8777eff2-d18d-4d43-bccc-ce24af9afde0.png"> |

