### PR TITLE
[FEAT] Close theme dialog when clicking away

### DIFF
--- a/ejs-views/partials/header.ejs
+++ b/ejs-views/partials/header.ejs
@@ -52,7 +52,7 @@
         <img src="/public/logo-name-navbar-dark.svg" class="h-10" />
       </a>
       <nav class="fixed flex-col text-center p-24 shadow-right md:static md:p-0 md:flex-row md:shadow-none md:h-auto flex z-10 h-screen top-0 -left-96 bg-accent gap-6 transition-all">
-        <i class="nav-toggle md:!hidden fas fa-times absolute top-5 right-5 text-white text-2xl cursor-pointer"></i>
+        <i onclick="toggleNavBtn()" class="md:!hidden fas fa-times absolute top-5 right-5 text-white text-2xl cursor-pointer"></i>
         <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/') { %> text-primary <% } %>" href="/">Featured</a>
         <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/packages') { %> text-primary <% } %>" href="/packages">Packages</a>
         <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/login') { %> text-primary <% } %>" href="/login">Sign In</a>
@@ -61,7 +61,7 @@
           Website
         </a>
       </nav>
-      <i class="nav-toggle md:!hidden fas fa-bars text-white opacity-80 text-2xl hover:opacity-100 cursor-pointer"></i>
+      <i onclick="toggleNavBtn()" class="md:!hidden fas fa-bars text-white opacity-80 text-2xl hover:opacity-100 cursor-pointer"></i>
       <div class="flex-1 text-right">
         <button onclick="changeThemeBtn()">Change Theme <i class="fas fa-caret-down ml-2"></i></button>
         <div class="hidden absolute bg-accent right-3 mt-12 p-3" id="dropdown-list">

--- a/public/site.js
+++ b/public/site.js
@@ -20,6 +20,10 @@ function changeTheme(theme) {
   }
 }
 
+function toggleNavBtn() {
+  document.querySelector('nav').classList.toggle('active');
+}
+
 function loadStats() {
   if (timetable) {
     console.log(timetable);
@@ -50,18 +54,10 @@ function copyToClipboard(triggerElement) {
 }
 
 window.onclick = function (event) {
-  if (!event.target.matches(".dropbtn")) {
-    let dropdowns = document.getElementsByClassName("dropdown-content");
-    for (let i = 0; i < dropdowns.length; i++) {
-      let openDropdown = dropdowns[i];
-      if (openDropdown.classList.contains("show")) {
-        openDropdown.classList.remove("show");
-      }
-    }
-  }
-  if (event.target.matches(".nav-toggle")) {
-    let nav = document.querySelector('nav');
-    nav.classList.toggle('active')
+  const dropdownList = document.getElementById("dropdown-list");
+  if (!event.target.matches("button") && dropdownList.classList.contains('show')) {
+    console.log('removing');
+    dropdownList.classList.remove('show');
   }
 };
 

--- a/public/site.js
+++ b/public/site.js
@@ -56,7 +56,6 @@ function copyToClipboard(triggerElement) {
 window.onclick = function (event) {
   const dropdownList = document.getElementById("dropdown-list");
   if (!event.target.matches("button") && dropdownList.classList.contains('show')) {
-    console.log('removing');
     dropdownList.classList.remove('show');
   }
 };


### PR DESCRIPTION
# Summary

As mentioned by @Spiker985 in [this message](https://discord.com/channels/992103415163396136/992275353961775145/1057200560345985064), the theme dropdown list should hide itself when you click away from the the box. Additionally, I noticed some residual code from the dropdown toggling functionality that was no longer being used.

### Edit:
@confused-Techie I opened the pull request for the wrong branch :)
