### PR TITLE
Another Pagination Responsiveness Fix

### DIFF
--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,7 +1,7 @@
 <% if (locals.pagination) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
         <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
-        <div class="flex items-center sm:gap-6 gap-3">
+        <div class="flex items-center sm:gap-6 lg:gap-3 md:gap-3">
             <a href="<%- pagination.routes.first %>" class="<%- !!pagination.routes.first ? '' : 'disabled' %>">
                 <i class="fas fa-chevron-left -mr-1"></i>
                 <i class="fas fa-chevron-left"></i>
@@ -13,12 +13,12 @@
 
             <% pagination.options.forEach(option => { %>
                 <a href="<%- option.value %>" class="<%= option.label == pagination.page ? 'active' : '' %>"><%= option.label %></a>
-            <% }); %> 
-    
+            <% }); %>
+
             <a href="<%- pagination.routes.next %>" class="<%- !!pagination.routes.next ? '' : 'disabled' %>">
                 <i class="fas fa-chevron-right"></i>
             </a>
-            
+
             <a href="<%- pagination.routes.last %>" class="<%- !!pagination.routes.last ? '' : 'disabled' %>">
                 <i class="fas fa-chevron-right -mr-1"></i>
                 <i class="fas fa-chevron-right"></i>

--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,7 +1,7 @@
 <% if (locals.pagination) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
         <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
-        <div class="flex items-center sm:gap-6 lg:gap-3 md:gap-3">
+        <div class="flex items-center gap-1 sm:gap-3 lg:gap-6">
             <a href="<%- pagination.routes.first %>" class="<%- !!pagination.routes.first ? '' : 'disabled' %>">
                 <i class="fas fa-chevron-left -mr-1"></i>
                 <i class="fas fa-chevron-left"></i>


### PR DESCRIPTION
Looks like on some screen sizes such as 375x667 (iPhone SE) I was still seeing some overflow on pagination icons.

Likely from the fact the `gap-3` class was always being applied. Moving that to only apply at `lg` and `md` sizes resolves this issue.