### PR TITLE
Improve our Markdown Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "js-yaml": "^4.1.0",
         "markdown-it": "^13.0.1",
         "markdown-it-emoji": "^2.0.2",
+        "markdown-it-github-headings": "^2.0.1",
         "markdown-it-highlightjs": "^4.0.1",
+        "markdown-it-task-checkbox": "^1.0.6",
         "superagent": "^8.0.1",
         "tailwindcss": "^3.2.4"
       },
@@ -2703,6 +2705,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2840,6 +2847,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3016,6 +3028,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/innertext": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.3.tgz",
+      "integrity": "sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==",
+      "dependencies": {
+        "html-entities": "^1.2.0"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3984,6 +4004,15 @@
       "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
       "integrity": "sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ=="
     },
+    "node_modules/markdown-it-github-headings": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-headings/-/markdown-it-github-headings-2.0.1.tgz",
+      "integrity": "sha512-5CeRu1ANVJcEqCWxhYoECzb/7Wx//mW1eu3AoU3AgJe+wbSf4+ct83jRTQO0jQr5BPEMxaGVL6lPNS9Vf9nlHg==",
+      "dependencies": {
+        "github-slugger": "^1.1.1",
+        "innertext": "^1.0.1"
+      }
+    },
     "node_modules/markdown-it-highlightjs": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-4.0.1.tgz",
@@ -3991,6 +4020,11 @@
       "dependencies": {
         "highlight.js": "^11.5.1"
       }
+    },
+    "node_modules/markdown-it-task-checkbox": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-checkbox/-/markdown-it-task-checkbox-1.0.6.tgz",
+      "integrity": "sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw=="
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -7779,6 +7813,11 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
     },
+    "github-slugger": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
+    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -7874,6 +7913,11 @@
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
       "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw=="
+    },
+    "html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -7997,6 +8041,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "innertext": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/innertext/-/innertext-1.0.3.tgz",
+      "integrity": "sha512-ZC410b7IbrTrmt8bQb27xUOJgXkJu+XL6MVncb9FGyxjRIHyQqNjpSDY20zvSUttkAiYj0dait/67/sXyWvwYg==",
+      "requires": {
+        "html-entities": "^1.2.0"
+      }
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -8738,6 +8790,15 @@
       "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
       "integrity": "sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ=="
     },
+    "markdown-it-github-headings": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-github-headings/-/markdown-it-github-headings-2.0.1.tgz",
+      "integrity": "sha512-5CeRu1ANVJcEqCWxhYoECzb/7Wx//mW1eu3AoU3AgJe+wbSf4+ct83jRTQO0jQr5BPEMxaGVL6lPNS9Vf9nlHg==",
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "innertext": "^1.0.1"
+      }
+    },
     "markdown-it-highlightjs": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-4.0.1.tgz",
@@ -8745,6 +8806,11 @@
       "requires": {
         "highlight.js": "^11.5.1"
       }
+    },
+    "markdown-it-task-checkbox": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-checkbox/-/markdown-it-task-checkbox-1.0.6.tgz",
+      "integrity": "sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw=="
     },
     "mdurl": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "js-yaml": "^4.1.0",
     "markdown-it": "^13.0.1",
     "markdown-it-emoji": "^2.0.2",
+    "markdown-it-github-headings": "^2.0.1",
     "markdown-it-highlightjs": "^4.0.1",
+    "markdown-it-task-checkbox": "^1.0.6",
     "superagent": "^8.0.1",
     "tailwindcss": "^3.2.4"
   },

--- a/src/site.css
+++ b/src/site.css
@@ -116,6 +116,22 @@ nav.active {
   @apply inline-block;
 }
 
+#readme ul {
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  padding-inline-start: 40px;
+}
+
+#readme hr {
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  border: 0;
+  background-color: var(--secondary);
+}
+
 /**************************/
 /****** PAGINATION ********/
 /**************************/

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,11 @@ let md = new MarkdownIt({
   inline: true
 }).use(require("markdown-it-emoji"), {
 
+}).use(require("markdown-it-github-headings"), {
+
+}).use(require("markdown-it-task-checkbox"), {
+  disabled: true,
+  divWrap: false
 });
 
 const reg = require("./reg.js");
@@ -209,8 +214,8 @@ function getPagination(req, api) {
     if (index < mid) {
       // Try to add next options
       // Note - These functions are the same, just switching priority
-      if (getNextPos() <= pages) { 
-        options.push(getNextPos()); 
+      if (getNextPos() <= pages) {
+        options.push(getNextPos());
       } else if (getPrevPos() >= 1) {
         options.unshift(getPrevPos());
       }
@@ -220,7 +225,7 @@ function getPagination(req, api) {
       if (getPrevPos() >= 1) {
         options.unshift(getPrevPos());
       } else if (getNextPos() <= pages) {
-        options.push(getNextPos()); 
+        options.push(getNextPos());
       }
     }
   });
@@ -232,7 +237,7 @@ function getPagination(req, api) {
   // Calculate to / from numbers
   const from = page === 1 ? 1 : ((page - 1) * limit) + 1;
   const to = (from + payloadLength) - 1;
-  
+
   return {
     from,
     to,


### PR DESCRIPTION
Resolves #43 

This PR adds additional Plugins to `markdown-it` to add the following features:
* GitHub Headings
  - Adds the GitHub type Icon to Markdown Headers
  - Adds Header Anchors 
* GitHub TaskLists
  - Supports GitHub Task Lists and checkboxes
  - These are disabled from being clickable
 
Also this PR mirrors some CSS styles that are used by GitHub Displayed Markdown for the `hr` or Page Break Element, and lists in general.

This improves our support for different Markdown elements, while focusing on making these look closer to how they would appear on GitHub as these Readmes (Especially while we only support GitHub) have been crafted for this platform.