### PR TITLE
Add Sharing Button and Functionality

### DIFF
--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -40,6 +40,46 @@
         </p>
       <% } %>
     </div>
+    <% if (typeof pack.share === "object") { %>
+    <div class="md:inline-block hidden sm:flex items-center justify-center mt-2 md:mt-0">
+    <!--<div class="inline-block items-center justify-center mt-2 md:mt-0">-->
+      <button onclick="shareDropDown()" class="w-full md:w-auto">
+        <i class="fa-solid fa-share-from-square"></i>
+        <span>Share</span>
+        <i class="fas fa-caret-down ml-2"></i>
+      </button>
+      <div class="absolute hidden border border-secondary bg-accent mt-5" id="share-dropdown-list">
+
+        <div class="flex p-2">
+          <button class="mr-2" style="white-space: nowrap;" id="sharePackageLink"
+            onclick="copyToClipboardAgnostic('<%=pack.share.pageLink%>', 'sharePackageLink')">
+            <i class="fas fa-clipboard mr-2"></i>
+            Package Link
+          </button>
+          <input type="text" disabled value="<%=pack.share.pageLink%>" class="bg-secondary"/>
+        </div>
+
+        <div class="flex p-2">
+          <button class="mr-2" style="white-space: nowrap;" id="shareMDLink"
+            onclick="copyToClipboardAgnostic('<%=pack.share.mdLink.default%>', 'shareMDLink')">
+            <i class="fas fa-clipboard mr-2"></i>
+            MarkDown Link
+          </button>
+          <input type="text" disabled value="<%=pack.share.mdLink.default%>" class="bg-secondary"/>
+        </div>
+
+        <div class="flex p-2">
+          <button class="mr-2" style="white-space: nowrap;" id="shareMDLinkIconic"
+            onclick="copyToClipboardAgnostic('<%=pack.share.mdLink.iconic%>', 'shareMDLinkIconic')">
+            <i class="fas fa-clipboard mr-2"></i>
+            Iconic MarkDown Link
+          </button>
+          <input type="text" disabled value="<%=pack.share.mdLink.iconic%>" class="bg-secondary"/>
+        </div>
+
+      </div>
+    </div>
+    <% } %>
     <a href="<%=pack.install%>" class="hidden sm:flex items-center justify-center mt-3 md:mt-0">
       <button class="w-full md:w-auto">
         <i class="fas fa-download mr-2"></i>

--- a/public/site.js
+++ b/public/site.js
@@ -24,6 +24,10 @@ function changeTheme(theme) {
   }
 }
 
+function shareDropDown() {
+  document.getElementById("share-dropdown-list").classList.toggle("show");
+}
+
 function toggleNavBtn() {
   document.querySelector('nav').classList.toggle('active');
 }
@@ -57,10 +61,35 @@ function copyToClipboard(triggerElement) {
   }
 }
 
+// Agnostic Copy to Clipboard for all Share Btns
+function copyToClipboardAgnostic(value, target) {
+  if (value && target) {
+    navigator.clipboard.writeText(value);
+
+    const element = document.getElementById(target);
+
+    // Store original value before manipulating
+    const label = element.innerText;
+
+    element.innerText = "Copied!";
+
+    // Reset to original button text after 3s
+    setTimeout(() => {
+      element.innerText = label;
+    }, 3000);
+  }
+}
+
 window.onclick = function (event) {
   const dropdownList = document.getElementById("dropdown-list");
   if (!event.target.matches("button") && dropdownList.classList.contains('show')) {
     dropdownList.classList.remove('show');
+  }
+  const shareDropDownList = document.getElementById("share-dropdown-list");
+  if (shareDropDownList) {
+    if (!event.target.matches("button") && shareDropDownList.classList.contains('show')) {
+      shareDropDownList.classList.remove('show');
+    }
   }
 };
 

--- a/src/site.css
+++ b/src/site.css
@@ -104,6 +104,18 @@ nav.active {
 }
 
 /**************************/
+/****** SHARE SELECT ******/
+/**************************/
+
+#share-dropdown-list.show {
+  @apply !block;
+}
+
+#share-dropdown-list:before {
+  @apply absolute -top-4 right-80 content-[''] w-0 h-0 border-8 border-transparent border-b-accent;
+}
+
+/**************************/
 /***** PACKAGE README *****/
 /**************************/
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -132,6 +132,15 @@ function prepareForDetail(obj) {
     pack.stars = Number(pack.stars).toLocaleString();
     pack.downloads = Number(pack.downloads).toLocaleString();
 
+    // Add Sharing data to it for easy access to the package_listing
+    pack.share = {
+      pageLink: `https://web.pulsar-edit.dev/packages/${pack.name}`,
+      mdLink: {
+        default: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name})](https://web.pulsar-edit.dev/packages/${pack.name})`,
+        iconic: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=iconic)](https://web.pulsar-edit.dev/packages/${pack.name})`
+      }
+    };
+
     resolve(pack);
   });
 }


### PR DESCRIPTION
This PR adds a `Share` button on the package detail view.

This Share button then allows the user to easily copy any of the available links to their clipboard for easy sharing. Currently these links include 

* Package Link (Generic link to the page)
* MarkDown Link (MarkDown text where the social image card is used as an icon)
* Iconic MarkDown Link (MarkDown text where the social image card Iconic variant is used as an icon)

This aims to allow easier use of the social image cards for package maintainers as well as help things feel a bit more modern.

![image](https://user-images.githubusercontent.com/26921489/215692746-a4a0da35-6721-4165-9f9e-9dcaef8db5fe.png)

---

Additionally this PR Closes #50 