### PR TITLE
Create new Auth-State-Cleanup Microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ This allows the Pulsar Discord to get GitHub Sponsors notifications directly, an
 
 For more information, take a look at the [Webhooks Microservice Readme](./microservices/webhooks/README.md).
 
+### Auth State Cleanup
+
+The Auth State Cleanup Microservice is a scheduled task that helps to cleanup the public Database in use for Pulsar.
+
+Automatically deleted expired Secret Auth Codes that are generated for security during the GitHub OAuth Signup process for new users.
+
+For more information, take a look at the [Auth State Cleanup Readme](./microservices/auth-state-cleanup/README.md).
+
 ## Developing the Frontend
 
 The Frontend alone is a rather simple NodeJS package, and is made to run smoothly for local development or testing.

--- a/microservices/auth-state-cleanup/.config
+++ b/microservices/auth-state-cleanup/.config
@@ -8,4 +8,16 @@ This service is intended to be run on the Google Cloud App Run service.
     - Cloud Run Invoker
     - Secret Manager Secret Accessor
 
-- cloud schedule 
+- cloud schedule
+  name: auth-state-cleanup-job
+  region: us-west1
+  description: Runs the Auth-State-Cleanup App Run Microservice
+  frequency: 0 */5 * * *
+  timezone: PST
+
+  target_type: HTTP
+  url: https://auth-state-cleanup-z6y5uvh2fq-uw.a.run.app/
+  HTTP_method: POST
+  auth_header: Add OIDC token
+  service_account: frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
+  audience: https://auth-state-cleanup-z6y5uvh2fq-uw.a.run.app

--- a/microservices/auth-state-cleanup/.config
+++ b/microservices/auth-state-cleanup/.config
@@ -1,0 +1,11 @@
+This configuration file is not used anywhere in the source code.
+This configuration file exists soley to allow easy reproduction of the settings used for this service if needed.
+
+This service is intended to be run on the Google Cloud App Run service.
+
+- service account
+  roles:
+    - Cloud Run Invoker
+    - Secret Manager Secret Accessor
+
+- cloud schedule 

--- a/microservices/auth-state-cleanup/.dockerignore
+++ b/microservices/auth-state-cleanup/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+node_modules/
+README.md
+.config

--- a/microservices/auth-state-cleanup/.gcloudignore
+++ b/microservices/auth-state-cleanup/.gcloudignore
@@ -1,0 +1,3 @@
+node_modules/
+README.md
+.config

--- a/microservices/auth-state-cleanup/Dockerfile
+++ b/microservices/auth-state-cleanup/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM node:18-slim
+
+# Below we use Dockerfile Labels w/ predefined annotation keys to properly link to arbitrary
+# container images to the proper Pulsar Repo.
+LABEL org.opencontainers.artifact.description="Microservice to Cleanup our Database AuthState Table"
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend"
+LABEL org.opencontainers.image.author="confused-Techie"
+LABEL org.opencontainers.image.license="MIT"
+LABEL description="Microservice to Cleanup our Database AuthState Table"
+
+# Create and change to the app directory
+WORKDIR /usr/src/app
+
+# Copy application dependency manifests to the other image.
+COPY package*.json ./
+
+# Install production dependencies
+RUN npm install --only=production
+
+# Copy local code to the container image.
+COPY . ./
+
+# Run the web service on container startup
+CMD [ "npm", "start" ]

--- a/microservices/auth-state-cleanup/README.md
+++ b/microservices/auth-state-cleanup/README.md
@@ -1,0 +1,15 @@
+# Auth State Cleanup
+
+This Microservice is a scheduled task that runs a cleanup job on Pulsar User Database.
+
+For security during the sign up process Pulsar Generates secret `codes`. These codes are used to verify the legitimacy of a request when a user signs up for Pulsar via GitHubs OAuth signup. But after the signup flow these `codes` are not deleted automatically.
+
+So this job then is in charge of deleted `codes` that have reached their expiration date.
+
+## Publishing
+
+Like all other microservices, the publishing flow will require building with Docker
+
+And then uploading to GitHub. Then to retag and upload to Google Cloud.
+
+To update the service replace the `service.yaml` file in the cloud to the newest version.

--- a/microservices/auth-state-cleanup/index.js
+++ b/microservices/auth-state-cleanup/index.js
@@ -1,13 +1,14 @@
 const http = require("http");
+const postgres = require("postgres");
 const port = parseInt(process.env.PORT) || 8080;
 
 // DB variables
-const db_host = process.env.DB_HOST;
-const db_user = process.env.DB_USER;
-const db_pass = process.env.DB_PASS;
-const db_db = process.env.DB_DB;
-const db_port = process.env.DB_PORT;
-const db_ssl_cert = process.env.DB_SSL_CERT;
+const db_host = process.env.ASC_MICROSERVICE_DB_HOST;
+const db_user = process.env.ASC_MICROSERVICE_DB_USER;
+const db_pass = process.env.ASC_MICROSERVICE_DB_PASS;
+const db_db = process.env.ASC_MICROSERVICE_DB_DB;
+const db_port = process.env.ASC_MICROSERVICE_DB_PORT;
+const db_ssl_cert = process.env.ASC_MICROSERVICE_DB_SSL_CERT;
 
 let sql;
 
@@ -16,7 +17,7 @@ const server = http.createServer(async (req, res) => {
 
   if (path[0] === "/" && req.method === "POST") {
 
-    console.log(`Auth-State-Cleanup Job Triggered: ${req.url} - ${req.getHeader("User-Agent")}`);
+    console.log(`Auth-State-Cleanup Job Triggered: ${req.url} - ${req.headers["user-agent"]}`);
 
     let job = await runJob();
 
@@ -51,13 +52,13 @@ function setupSQL() {
   return process.env.PULSAR_STATUS === "dev"
     ? postgres({
       host: db_host,
-      username: db_username,
+      username: db_user,
       database: db_db,
       port: db_port
     })
     : postgres({
       host: db_host,
-      username: db_username,
+      username: db_user,
       password: db_pass,
       database: db_db,
       port: db_port,

--- a/microservices/auth-state-cleanup/index.js
+++ b/microservices/auth-state-cleanup/index.js
@@ -1,0 +1,104 @@
+const http = require("http");
+const port = parseInt(process.env.PORT) || 8080;
+
+// DB variables
+const db_host = process.env.DB_HOST;
+const db_user = process.env.DB_USER;
+const db_pass = process.env.DB_PASS;
+const db_db = process.env.DB_DB;
+const db_port = process.env.DB_PORT;
+const db_ssl_cert = process.env.DB_SSL_CERT;
+
+const sql;
+
+const server = http.createServer(async (req, res) => {
+  const path = req.url.split("?"); // strip any query params
+
+  if (path[0] === "/" && req.method === "POST") {
+
+    console.log(`Auth-State-Cleanup Job Triggered: ${req.url} - ${req.getHeader("User-Agent")}`);
+
+    let job = await runJob();
+
+    if (!job.ok) {
+      console.log(`Auth-State-Cleanup Job FAILED: ${job}`);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.write(JSON.stringify({ message: "The Job Failed" }));
+      res.end();
+    }
+
+    // The job succeeded
+    console.log(`Auth-State-Cleanup Job SUCCESS: ${job.content}`);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.write(JSON.stringify({ message: "Success!" }));
+    res.end();
+
+    // Disconnect our DB connection
+    shutdownSQL();
+
+  } else {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.write(JSON.stringify({ message: "Location Not Found" }));
+    res.end();
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Auth-State-Cleanup Microservice Exposed on Port: ${port}`);
+});
+
+function setupSQL() {
+  return process.env.PULSAR_STATUS === "dev"
+    ? postgres({
+      host: db_host,
+      username: db_username,
+      database: db_db,
+      port: db_port
+    })
+    : postgres({
+      host: db_host,
+      username: db_username,
+      password: db_pass,
+      database: db_db,
+      port: db_port,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: db_ssl_cert
+      }
+    });
+}
+
+function shutdownSQL() {
+  if (sql !== undefined) {
+    sql.end();
+    console.log("Auth-State-Cleaup Shutdown SQL Connection!");
+  }
+  return;
+}
+
+async function runJob() {
+  try {
+    sql ??= setupSQL();
+
+    const command = await sql`
+      DELETE FROM authstate
+      WHERE created < CURRENT_TIMESTAMP - INTERVAL '10 minutes';
+    `;
+
+    console.log("Auth-State-Cleanup Run with output below:");
+    console.log(command);
+
+    return {
+      ok: true,
+      content: command
+    };
+
+  } catch(err) {
+    console.log("Auth-State-Cleanup Encountered an Error!");
+    console.log(err);
+    return {
+      ok: false,
+      content: err
+    };
+  }
+}

--- a/microservices/auth-state-cleanup/index.js
+++ b/microservices/auth-state-cleanup/index.js
@@ -9,7 +9,7 @@ const db_db = process.env.DB_DB;
 const db_port = process.env.DB_PORT;
 const db_ssl_cert = process.env.DB_SSL_CERT;
 
-const sql;
+let sql;
 
 const server = http.createServer(async (req, res) => {
   const path = req.url.split("?"); // strip any query params

--- a/microservices/auth-state-cleanup/package-lock.json
+++ b/microservices/auth-state-cleanup/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "auth-state-cleanup",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auth-state-cleanup",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "postgres": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=16.16.0"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.3.tgz",
+      "integrity": "sha512-FGLZOpZSXePRIQu6LJpJUDikzuhplWI80uyyfmKBiljpfO+Z4nuClwpq3/dsRnitxVDsgFN5duJ7eUTaC0meQQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    }
+  },
+  "dependencies": {
+    "postgres": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.3.tgz",
+      "integrity": "sha512-FGLZOpZSXePRIQu6LJpJUDikzuhplWI80uyyfmKBiljpfO+Z4nuClwpq3/dsRnitxVDsgFN5duJ7eUTaC0meQQ=="
+    }
+  }
+}

--- a/microservices/auth-state-cleanup/package.json
+++ b/microservices/auth-state-cleanup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-state-cleanup",
-  "version": "1.0.1",
+  "version": "1.0.5",
   "description": "Microservice to Cleanup our Database AuthState Table",
   "main": "index.js",
   "scripts": {

--- a/microservices/auth-state-cleanup/package.json
+++ b/microservices/auth-state-cleanup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-state-cleanup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microservice to Cleanup our Database AuthState Table",
   "main": "index.js",
   "scripts": {

--- a/microservices/auth-state-cleanup/package.json
+++ b/microservices/auth-state-cleanup/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "auth-state-cleanup",
+  "version": "1.0.0",
+  "description": "Microservice to Cleanup our Database AuthState Table",
+  "main": "index.js",
+  "scripts": {
+    "start": "node ./index.js"
+  },
+  "engines": {
+    "node": ">=16.16.0"
+  },
+  "author": "confused-Techie",
+  "license": "MIT",
+  "dependencies": {
+    "postgres": "^3.3.3"
+  }
+}

--- a/microservices/auth-state-cleanup/policy.yaml
+++ b/microservices/auth-state-cleanup/policy.yaml
@@ -1,0 +1,4 @@
+bindings:
+  - members:
+    - serviceAccount:frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
+    role: roles/run.invoker

--- a/microservices/auth-state-cleanup/service.yaml
+++ b/microservices/auth-state-cleanup/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
-metedata:
+metadata:
   name: auth-state-cleanup
 spec:
   template:
     spec:
-      serviceAccoutName: frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
+      serviceAccountName: frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
       containers:
-      - image: "us-west2-docker-pkg.dev/pulsar-357404/package-frontend/auth-state-cleanup:1.0.0"
+      - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/auth-state-cleanup:1.0.1"
         env:
         - name: ASC_MICROSERVICE_DB_HOST
           valueFrom:

--- a/microservices/auth-state-cleanup/service.yaml
+++ b/microservices/auth-state-cleanup/service.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       serviceAccountName: frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
       containers:
-      - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/auth-state-cleanup:1.0.1"
+      - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/auth-state-cleanup:1.0.5"
         env:
         - name: ASC_MICROSERVICE_DB_HOST
           valueFrom:

--- a/microservices/auth-state-cleanup/service.yaml
+++ b/microservices/auth-state-cleanup/service.yaml
@@ -1,0 +1,41 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metedata:
+  name: auth-state-cleanup
+spec:
+  template:
+    spec:
+      serviceAccoutName: frontend-asc-bot@pulsar-357404.iam.gserviceaccount.com
+      containers:
+      - image: "us-west2-docker-pkg.dev/pulsar-357404/package-frontend/auth-state-cleanup:1.0.0"
+        env:
+        - name: ASC_MICROSERVICE_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_HOST
+        - name: ASC_MICROSERVICE_DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_USER
+        - name: ASC_MICROSERVICE_DB_PASS
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_PASS
+        - name: ASC_MICROSERVICE_DB_DB
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_DB
+        - name: ASC_MICROSERVICE_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_PORT
+        - name: ASC_MICROSERVICE_DB_SSL_CERT
+          valueFrom:
+            secretKeyRef:
+              key: latest
+              name: ASC_MICROSERVICE_DB_SSL_CERT


### PR DESCRIPTION
This microservice helps to cleanup Pulsars Public database.

The need for this has been described many times, but most succinctly over on [`pulsar-backend#67`](https://github.com/pulsar-edit/package-backend/issues/67).

In short during the GitHub OAuth Signup flow, we need to generate temporary codes to ensure returning users to the signup  flow are in fact returning.

This scheduled task then will go ahead and delete expired tokens to reduce the amount of clutter in our database.