### PR TITLE
Add Search bar to `/packages` page

### DIFF
--- a/ejs-views/pages/package_list.ejs
+++ b/ejs-views/pages/package_list.ejs
@@ -1,6 +1,7 @@
 <%- include('../partials/header', { page }); %>
 
 <article>
+  <%- include('../partials/search_bar'); %>
   <%- include('../partials/pagination'); %>
   <%- include('../partials/package_grid', { packages }); %>
   <%- include('../partials/pagination'); %>


### PR DESCRIPTION
This PR is simple and based on a passing recommendation from one of our users.

This just adds the search bar to the `/packages` page so that you are always able to search for packages.