### PR TITLE
Various UI-related fixes

### DIFF
--- a/ejs-views/partials/header.ejs
+++ b/ejs-views/partials/header.ejs
@@ -67,12 +67,12 @@
           Website
         </a>
         <div class="relative flex-1 text-right">
-          <button onclick="changeThemeBtn()">Change Theme <i class="fas fa-caret-down ml-2"></i></button>
+          <button class="change-theme">Change Theme <i class="fas fa-caret-down ml-2"></i></button>
           <div class="hidden absolute bg-accent text-left md:text-right md:mt-8 p-3 min-w-[200px] md:right-0" id="dropdown-list">
-            <button onclick="changeTheme('original-theme')">Atom.io (Default)</button><br>
-            <button onclick="changeTheme('github-dark')">GitHub Dark</button><br>
-            <button onclick="changeTheme('dracula')">Dracula</button><br>
-            <button onclick="changeTheme('one-dark')">One Dark</button>
+            <button data-theme-name="original-theme">Atom.io (Default)</button>
+            <button data-theme-name="github-dark">GitHub Dark</button>
+            <button data-theme-name="dracula">Dracula</button>
+            <button data-theme-name="one-dark">One Dark</button>
           </div>
         </div>
 

--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -43,18 +43,18 @@
     <% if (typeof pack.share === "object") { %>
     <div class="md:inline-block hidden sm:flex items-center justify-center mt-2 md:mt-0">
     <!--<div class="inline-block items-center justify-center mt-2 md:mt-0">-->
-      <button onclick="shareDropDown()" class="w-full md:w-auto">
+      <button class="share-button" class="w-full md:w-auto">
         <i class="fa-solid fa-share-from-square"></i>
         <span>Share</span>
         <i class="fas fa-caret-down ml-2"></i>
       </button>
-      <div class="absolute hidden border border-secondary bg-accent mt-5" id="share-dropdown-list">
+      <div class="absolute hidden border border-secondary bg-accent mt-3" id="share-dropdown-list">
 
         <div class="flex p-2">
           <button class="mr-2" style="white-space: nowrap;" id="sharePackageLink"
             onclick="copyToClipboardAgnostic('<%=pack.share.pageLink%>', 'sharePackageLink')">
             <i class="fas fa-clipboard mr-2"></i>
-            Package Link
+            <span>Package Link</span>
           </button>
           <input type="text" disabled value="<%=pack.share.pageLink%>" class="bg-secondary"/>
         </div>
@@ -63,7 +63,7 @@
           <button class="mr-2" style="white-space: nowrap;" id="shareMDLink"
             onclick="copyToClipboardAgnostic('<%=pack.share.mdLink.default%>', 'shareMDLink')">
             <i class="fas fa-clipboard mr-2"></i>
-            MarkDown Link
+            <span>MarkDown Link</span>
           </button>
           <input type="text" disabled value="<%=pack.share.mdLink.default%>" class="bg-secondary"/>
         </div>
@@ -72,7 +72,7 @@
           <button class="mr-2" style="white-space: nowrap;" id="shareMDLinkIconic"
             onclick="copyToClipboardAgnostic('<%=pack.share.mdLink.iconic%>', 'shareMDLinkIconic')">
             <i class="fas fa-clipboard mr-2"></i>
-            Iconic MarkDown Link
+            <span>Iconic MarkDown Link</span>
           </button>
           <input type="text" disabled value="<%=pack.share.mdLink.iconic%>" class="bg-secondary"/>
         </div>

--- a/src/site.css
+++ b/src/site.css
@@ -103,6 +103,10 @@ nav.active {
   @apply absolute -top-4 right-10 content-[''] w-0 h-0 border-8 border-transparent border-b-accent;
 }
 
+#dropdown-list button {
+  display: block;
+}
+
 /**************************/
 /****** SHARE SELECT ******/
 /**************************/
@@ -112,7 +116,12 @@ nav.active {
 }
 
 #share-dropdown-list:before {
-  @apply absolute -top-4 right-80 content-[''] w-0 h-0 border-8 border-transparent border-b-accent;
+  right: 50%;
+  @apply absolute -top-4 content-[''] w-0 h-0 border-8 border-transparent border-b-accent;
+}
+
+#share-dropdown-list button {
+  min-width: 200px;
 }
 
 /**************************/


### PR DESCRIPTION
Some of these changes were mooted on Discord.

Off the top of my head:

* Clicking anywhere in the share button will open the menu as expected (no weird “dead zones”)
* When the share overlay appears, it's dynamically positioned beneath the share button
* Removed a handful of `onclick` attributes and props in favor of `addEventListener`
* Clicking on any of the clipboard-copy buttons no longer removes the accompanying icon
* Style the change-theme buttons as `display: block` instead of the `<br>`s
* Setup function moved to `DOMContentLoaded` instead of `window.onload` (don't need to wait for all external assets to load)

Some of the CSS changes can probably be done another way through Tailwind, but I'll let you Tailwind zealots argue over that.

All these things work for me locally in Firefox, but please do try them in another browser to be sure.

The share panel still looks weird to me with three buttons of varying width, but I have no idea what to do about that.