### PR TITLE
Fix Share Code Block Background Colour

### DIFF
--- a/src/site.css
+++ b/src/site.css
@@ -120,6 +120,10 @@ nav.active {
   @apply absolute -top-4 content-[''] w-0 h-0 border-8 border-transparent border-b-accent;
 }
 
+#share-dropdown-list input {
+  background-color: var(--canvas);
+}
+
 /**************************/
 /***** PACKAGE README *****/
 /**************************/


### PR DESCRIPTION
This PR resolves the issue of the share code block color on the default theme causing low contrast.

Before:

![image](https://user-images.githubusercontent.com/26921489/217406437-8369d45a-26f1-4f11-bcf6-cc7e22805157.png)

After:

![image](https://user-images.githubusercontent.com/26921489/217406355-589028c1-1918-4418-a8d3-ac85cf61671b.png)

Resolves #63 