### PR TITLE
Download microservice: Check task status, plus some refactoring

### DIFF
--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -130,9 +130,9 @@ async function findLink(os, type) {
 
     let buildID;
 
-    for (let i = 0; i < repositoryGraph.data.repository.builds.edges.length; i++) {
-      if (repositoryGraph.data.repository.builds.edges[i].node.status === "COMPLETED") {
-        buildID = repositoryGraph.data.repository.builds.edges[i].node.id;
+    for (const edge of repositoryGraph.data.repository.builds.edges) {
+      if (edge.node.status === "COMPLETED") {
+        buildID = edge.node.id;
         break;
       }
     }
@@ -153,10 +153,10 @@ async function findLink(os, type) {
 
     let taskid = undefined;
 
-    const findID = function (name, builds) {
-      for (let i = 0; i < builds.length; i++) {
-        if (builds[i].name === name && builds[i].status === "COMPLETED") {
-          return builds[i].id;
+    const findID = function (name, tasks) {
+      for (const task of tasks) {
+        if (task.name === name && task.status === "COMPLETED") {
+          return task.id;
         }
       }
       return undefined;
@@ -212,14 +212,14 @@ async function findLink(os, type) {
     let binaryPath = undefined;
 
     const findBinary = function (ext, loc, binaries) {
-      for (let i = 0; i < binaries.length; i++) {
+      for (const binary of binaries) {
         if (loc === "start") {
-          if (binaries[i].path.startsWith(ext)) {
-            return binaries[i].path;
+          if (binary.path.startsWith(ext)) {
+            return binary.path;
           }
         } else if (loc === "end") {
-          if (binaries[i].path.endsWith(ext)) {
-            return binaries[i].path;
+          if (binary.path.endsWith(ext)) {
+            return binary.path;
           }
         }
       }

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -111,7 +111,7 @@ async function displayError(req, res, errMsg) {
 
 async function findLink(os, type) {
   try {
-    let baseQuery = `
+    let repositoryQuery = `
       query getRepositoryBuildStatuses {
         repository(id: 6483909499158528) {
           builds(branch: "master", last: 10) {
@@ -126,13 +126,13 @@ async function findLink(os, type) {
       }
     `;
 
-    let baseGraph = await doRequest(baseQuery);
+    let repositoryGraph = await doRequest(repositoryQuery);
 
     let buildID;
 
-    for (let i = 0; i < baseGraph.data.repository.builds.edges.length; i++) {
-      if (baseGraph.data.repository.builds.edges[i].node.status === "COMPLETED") {
-        buildID = baseGraph.data.repository.builds.edges[i].node.id;
+    for (let i = 0; i < repositoryGraph.data.repository.builds.edges.length; i++) {
+      if (repositoryGraph.data.repository.builds.edges[i].node.status === "COMPLETED") {
+        buildID = repositoryGraph.data.repository.builds.edges[i].node.id;
         break;
       }
     }

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -115,14 +115,7 @@ async function findLink(os, type) {
       query getRepositoryBuildStatuses {
         repository(id: 6483909499158528) {
           builds(branch: "master", last: 10) {
-            pageInfo {
-              hasNextPage
-              hasPreviousPage
-              startCursor
-              endCursor
-            }
             edges {
-              cursor
               node {
                 id
                 status
@@ -147,7 +140,6 @@ async function findLink(os, type) {
     let buildQuery = `
       query GetTasksFromBuild {
         build(id: "${buildID}") {
-          status
           tasks {
             name
             id
@@ -206,15 +198,9 @@ async function findLink(os, type) {
     let taskQuery = `
       query GetTaskDetails {
         task(id: ${taskid}) {
-          name
-          status
           artifacts {
-            name
-            type
-            format
             files {
               path
-              size
             }
           }
         }

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -151,6 +151,7 @@ async function findLink(os, type) {
           tasks {
             name
             id
+            status
           }
         }
       }
@@ -162,7 +163,7 @@ async function findLink(os, type) {
 
     const findID = function (name, builds) {
       for (let i = 0; i < builds.length; i++) {
-        if (builds[i].name == name) {
+        if (builds[i].name === name && builds[i].status === "COMPLETED") {
           return builds[i].id;
         }
       }


### PR DESCRIPTION
### Main Point (bug fix)

Should Fix: https://github.com/pulsar-edit/package-frontend/issues/71

First commit in this PR fixes an issue with failing to find built binaries.

<details><summary>Details of the issue (click to expand):</summary>

The issue happened because, after we narrow in on the most-recent overall "COMPLETED" (passing) status build, we were implicitly assuming all tasks (jobs) were also passing. So we only checked that these tasks were the OS+arch we were looking for. Whereas it's possible for a job to fail and be re-run, for instance if Cirrus aborts and auto-reschedules the task. (Or if the first run simply fails and a subsequent run passes.)
 
</details>

Solution:

Indeed, overall passing builds can contain failing tasks/jobs (which would have been later re-run until they passed, but the failing tasks/jobs are still stored separately in there). We must filter for only the passing tasks/jobs.

### Miscellaneous Changes (refactoring/renaming/pruning some stuff)

The other commits I have included in this job are refactoring some code style, renaming a few variable names, and pruning out any query parameters on the Cirrus queries where we're not currently using the resulting data.

For details of the refactoring/renaming/pruning stuff, please see the commit messages and diff for details.

### Thoughts / Priorities

It's not a super huge PR, hopefully reviewer(s) will not mind the refactoring bits. In my view, the bug fix (first commit) is my main priority, the rest is more debatable or subjective and I would be willing to back those out (or move them to a separate PR) if it helps this PR be more easily reviewable and mergeable.

Thanks for taking a look.