### PR TITLE
Bump `download` Microservice

### DIFF
--- a/microservices/download/package-lock.json
+++ b/microservices/download/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "download-microservice",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "download-microservice",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "engines": {
         "node": ">=16.16.0"

--- a/microservices/download/package.json
+++ b/microservices/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-microservice",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Microservice to Redirect to our Cirrus CI Builds Correctly",
   "main": "index.js",
   "scripts": {
@@ -11,6 +11,5 @@
   },
   "author": "confused-Techie",
   "license": "MIT",
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/microservices/download/service.yaml
+++ b/microservices/download/service.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-        - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/download:1.0.2"
+        - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/download:1.0.3"


### PR DESCRIPTION
This PR was automatically done, by using the new script to bump the microservice version and update production from #69 

Publishing the changes available from #72 