### PR TITLE
Package Data Verification

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -42,6 +42,32 @@ function prepareForListing(obj) {
 
     for (let i = 0; i < obj.length; i++) {
       try {
+        // Lets first check that we can safely grab all the data we need
+        // https://github.com/pulsar-edit/package-frontend/issues/74
+        const valid = (obj[i]?.name ?? false) &&
+                      (obj[i]?.metadata?.keywords ?? false) &&
+                      (obj[i]?.downloads ?? false) &&
+                      (obj[i]?.stargazers_count ?? false) &&
+                      (obj[i]?.metadata?.description ?? false) &&
+                      (obj[i]?.metadata?.author ?? false);
+        if (!valid) {
+          // One of our strict checks has failed, so we know the object is invalid
+          // Instead of appending placeholder data like below for a single
+          // check failing, we will add in data asking for users to alert us of
+          // this broken package, so that it can be repaired
+          let brokenPack = {
+            name: pack?.name || "Malformed Package", // We still want to report a name for users to submit
+            description: `Whoops! Seems this package has severly malformed data. Please submit an issue to https://github.com/pulsar-edit/package-backend/issue with the package's name. Thank you!`,
+            keywords: [ "malformed" ],
+            author: "malformed",
+            downloads: 0,
+            stars: 0,
+            install: ""
+          };
+          packList.push(brokenPack);
+          continue;
+        }
+
         let pack = {};
 
         pack.name = obj[i].name ? obj[i].name : "";


### PR DESCRIPTION
I've added some strict package data verification on this PR.

Currently there are some light protections against receiving invalid or unexpected data, where the frontend will normally insert placeholder data to still be able to render the package, but now at the start of every package listing occurring the frontend will validate that every piece of data it needs is safely available, then if not will instead inject a message into the data of the package asking that the user could please submit an issue to our `package-backend` with the name of the package so that we can resolve the issue on the backend.

This helps to not hide the issue, and have us get all of these properly resolved. Additionally of course this means the package is still able to be rendered properly and not crash the entire frontend when trying to access/modify properties of an object that don't exist.

Sometime in the future when we are confident that we don't have any broken packages still in the system ideally we could strengthen the ability for a package to replace bad parts of the package and not provide this big error message. But for now it seems important that we can get every package fixed, at least until we can find a way to automatically check every package on the backend for validity.

Resolves #74 