### PR TITLE
Bump NodeJS + Stop Highlighting Inline Code Blocks

### DIFF
--- a/app.example.yaml
+++ b/app.example.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs16
+runtime: nodejs18
 service: package-browser
 
 env_variables:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "mini:css": "minify ./public/site.css > ./public/site.min.css",
     "deploy_script": "echo 'Do not run!' && gcloud app deploy"
   },
+  "engines": {
+    "node": ">=16 <=18"
+  },
   "author": "confused-Techie",
   "license": "MIT",
   "dependencies": {

--- a/src/site.css
+++ b/src/site.css
@@ -159,6 +159,13 @@ nav.active {
   background-color: var(--secondary);
 }
 
+#readme :not(pre) code {
+  padding: 0.2em 0.4em;
+  border-radius: 6px;
+  background-color: var(--secondary);
+  color: var(--text);
+}
+
 /**************************/
 /****** PAGINATION ********/
 /**************************/

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ let md = new MarkdownIt({
 }).use(require("markdown-it-highlightjs"), {
   auto: true,
   code: true,
-  inline: true
+  inline: false
 }).use(require("markdown-it-emoji"), {
 
 }).use(require("markdown-it-github-headings"), {


### PR DESCRIPTION
This PR tackles two small changes.

## Bump NodeJS 

This was simply changing the NodeJS being used in the `app.yaml` and testing. It's been also added to the `engines` field for good measure.

Resolves #70 

## Stop Highlighting Inline Code Blocks

For this we had to disable `markdown-it-highlightjs` `inline` and set it to `false`.
This was enough to stop only highlighting any inline code blocks. But from there they had unreadable styling, so I've added some simple CSS to ensure they are properly styled. Adding the `--secondary` from the theme as a background color, with a border-radius and some padding. Also ensuring the text is readable by setting that to `--text` of the theme.

Then to ensure these new CSS changes don't affect our existing code highlighting I've added the pseudo selector `:not(pre)` 

Resolves #78 

---

![image](https://user-images.githubusercontent.com/26921489/220577052-8b365b2e-4b8d-4120-9b2f-107e7ef9088f.png)

---

A photo from the problem package `latex-tree` with our changes

Compared to now:

---

![image](https://user-images.githubusercontent.com/26921489/220577243-3f3003a8-b042-4e64-bd55-40ac87933186.png)
