### PR TITLE
Clean up code blocks in READMEs

### DIFF
--- a/src/site.css
+++ b/src/site.css
@@ -159,6 +159,12 @@ nav.active {
   background-color: var(--secondary);
 }
 
+#readme code:not(.hljs) {
+  background-color: var(--secondary);
+  border-radius: 3px;
+  padding: 2px 5px;
+}
+
 /**************************/
 /****** PAGINATION ********/
 /**************************/

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,9 +4,9 @@ const url = require('url');
 let md = new MarkdownIt({
   html: true
 }).use(require("markdown-it-highlightjs"), {
-  auto: true,
+  auto: false,
   code: true,
-  inline: true
+  inline: false
 }).use(require("markdown-it-emoji"), {
 
 }).use(require("markdown-it-github-headings"), {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,8 +16,23 @@ module.exports = {
       typography: {
         DEFAULT: {
           css: {
+            'code::before': {
+              content: 'none'
+            },
+            'code::after': {
+              content: 'none'
+            },
             color: 'var(--text)',
             a: { color: 'var(--text)' },
+            code: {
+              color: 'var(--text)',
+              'font-weight': '500'
+            },
+            pre: {
+              'background-color': 'transparent',
+              'padding': '0',
+              'border': '2px solid var(--secondary)'
+            },
             strong: { color: 'var(--text)' },
             th: { color: 'var(--text)' },
             h1: { color: 'var(--text)' },


### PR DESCRIPTION
I just noticed @confused-Techie did a version of this as part of #79, but I was already done with this and I thought I'd just toss it out here and see what people think. This is a follow-up to #78, which I filed a few days ago.

This PR:
* removes syntax highlighting for inline `code` elements _and_ for fenced backticks that do not declare a language. (The `auto` flag means that highlightjs will guess at the language — and often guess wrongly. GitHub doesn't guess at the language when rendering these READMEs, so I don't think we ought to guess either.)
* Removes the backticks that `@tailwindcss/typography` inexplicably puts around inline `code` elements.
* Tries to resolve the style conflicts between highlightjs and `@tailwindcss/typography` by putting the former in control. The strange bezel-looking thing around `pre` blocks happens because `@tailwindcss/typography` wants them to be black, but highlightjs wants them to be white:

<img width="1042" alt="Screen Shot 2023-02-24 at 2 33 51 PM" src="https://user-images.githubusercontent.com/3450/221307815-14cd9fa9-7911-4880-828b-48c3051bc695.png">

To fix this, I removed the bezel altogether and replaced it with a subtle `var(--secondary)` border:

<img width="1043" alt="Screen Shot 2023-02-24 at 2 36 03 PM" src="https://user-images.githubusercontent.com/3450/221308504-d22f00c7-5144-40f9-81f3-e5c023066dea.png">

This approach seems to work quite well in each of our four themes.

Hey, here's a thought: at a certain point we'll be undoing so many of `@tailwindcss/typography`'s defaults that we could broach the idea of getting rid of it altogether. But that's a topic for another time.