### PR TITLE
Added GitHub Actions for Testing

### DIFF
--- a/.github/workflows/frontend_test.yml
+++ b/.github/workflows/frontend_test.yml
@@ -1,0 +1,35 @@
+# This GitHub Action is intended to run the tests present for the Package Frontend
+name: Package Frontend Tests Script
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'static/**'
+      - 'package.json'
+      - 'tailwind.config.js'
+      - 'public/**'
+      - 'ejs-views/**'
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Setup NodeJS - ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Run Tests
+      run: npm run test

--- a/.github/workflows/microservice_authstate_build_test.yml
+++ b/.github/workflows/microservice_authstate_build_test.yml
@@ -1,0 +1,21 @@
+# This GitHub Action is intended to simply test that the
+# Microservice AuthState Cleanup is able to build with Docker properly.
+name: Microservice Auth-State-Cleanup Docker Build
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'microservices/auth-state-cleanup/**'
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Build Docker Image
+      run: docker build .

--- a/.github/workflows/microservice_download_build_test.yml
+++ b/.github/workflows/microservice_download_build_test.yml
@@ -1,0 +1,21 @@
+# This GitHub Action is intended to simply test that the
+# Microservice Download is able to build with Docker properly.
+name: Microservice Download Docker Build
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'microservices/download/**'
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Build Docker Image
+      run: docker build .

--- a/.github/workflows/microservice_socialcards_build_test.yml
+++ b/.github/workflows/microservice_socialcards_build_test.yml
@@ -1,0 +1,21 @@
+# This GitHub Action is intended to simply test that the
+# Microservice Social-Cards is able to build with Docker properly.
+name: Microservice Social-Cards Docker Build
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'microservices/social-cards/**'
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Build Docker Image
+      run: docker build .

--- a/.github/workflows/microservice_webhooks_build_test.yml
+++ b/.github/workflows/microservice_webhooks_build_test.yml
@@ -1,0 +1,21 @@
+# This GitHub Action is intended to simply test that the
+# Microservice Webhooks is able to build with Docker properly.
+name: Microservice Webhooks Docker Build
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'microservices/webhooks/**'
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the latest code
+      uses: actions/checkout@v3
+
+    - name: Build Docker Image
+      run: docker build .


### PR DESCRIPTION
Since many of our Microservices don't include any kind of testing infrastructure as of yet, this implements a super simple way to at least partially test them, until of course they do support full test suites.

This PR introduces several GitHub actions that will test if they can build a Docker Image for each Microservice, as is done in production.

Additionally will run the limited number of tests that exist for the frontend.

This really is a reminder that we need better testing for all of these endpoints, since up until now it's been a manual process. But this should help us find the most breaking issues before reaching production.