### PR TITLE
Add Rich Site Information

### DIFF
--- a/ejs-views/partials/header.ejs
+++ b/ejs-views/partials/header.ejs
@@ -46,6 +46,45 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" />
     <!-- Set our Default Syntax Theme during page load so first time visitors don't have to wait for JS to execute -->
     <link rel="stylesheet" class="codestyle" id="syntax-theme" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/atom-one-light.min.css">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "url": "https://web.pulsar-edit.dev/",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://web.pulsar-edit.dev/packages/search?q={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "url": "https://pulsar-edit.dev/",
+        "logo": "https://web.pulsar-edit.dev/public/pulsar_name.svg"
+      },
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Pulsar",
+        "operatingSystem": [ "Windows", "OSX", "macOS", "Linux" ],
+        "applicationCategory": "DeveloperApplication",
+        "offers": {
+          "@type": "Offer",
+          "price": "0"
+        },
+        "downloadUrl": "https://pulsar-edit.dev/download.html",
+        "about": "A Community-led Hyper-Hackable Text Editor",
+        "description": "A Community-led Hyper-Hackable Text Editor",
+        "author": "Pulsar-Edit",
+        "inLanguage": "en-US",
+        "isBasedOn": "Atom",
+        "isBasedOnUrl": "https://github.com/atom"
+      }
+    </script>
   </head>
   <body class="bg-canvas flex flex-col min-h-screen text-text">
     <% if (timecop) { %>

--- a/ejs-views/partials/header.ejs
+++ b/ejs-views/partials/header.ejs
@@ -71,7 +71,7 @@
         "@type": "SoftwareApplication",
         "name": "Pulsar",
         "operatingSystem": [ "Windows", "OSX", "macOS", "Linux" ],
-        "applicationCategory": "DeveloperApplication",
+        "applicationCategory": [ "DeveloperApplication", "TextEditor" ],
         "offers": {
           "@type": "Offer",
           "price": "0"


### PR DESCRIPTION
This PR adds some Rich Site Data to the Pulsar Package Frontend, by adding some `JSON+LD` data to the header.

This data is modeled and in compliance with [Googles Structured Data Markup](https://developers.google.com/search/docs/appearance/structured-data/search-gallery) as well as (where relevant) [Schema.org](https://schema.org/SoftwareApplication)'s specifications for adding additional data beyond what is recommended by Google.

I've added three different elements here for this PR.

The first, is the branch name sake, getting the package search bar to appear on Search Engines Search results, such as Google's.

The other two aspects of extra data added, (in order of appearance) is some site organization information, that can help to build knowledge panels in search engines.

Then lastly I've added some `SoftwareApplication` structured data, which can help display the capabilities of Pulsar in search results. Specifically making it easier to find supported operating systems, and download URLs. This is where for good measure I added some components not mentioned in the Google specs to try and work on as many platforms as possible.