### PR TITLE
Fix the warning given for Malformed packages

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -55,7 +55,7 @@ function prepareForListing(obj) {
           // this broken package, so that it can be repaired
           let brokenPack = {
             name: obj[i]?.name || "Malformed Package", // We still want to report a name for users to submit
-            description: `Whoops! Seems this package has severly malformed data. Please submit an issue to https://github.com/pulsar-edit/package-backend/issue with the package's name. Thank you!`,
+            description: `Whoops! Seems this package has severely malformed data. Please submit an issue to https://github.com/pulsar-edit/package-backend/issues with the package's name. Thank you!`,
             keywords: [ "malformed" ],
             author: "malformed",
             downloads: 0,


### PR DESCRIPTION
The warning given when the frontend finds a malformed package included a spelling mistake and a missing character from the issue URL.

This PR resolves both of those issues as reported in [`package-backend:#125`](https://github.com/pulsar-edit/package-backend/issues/125)