### PR TITLE
Theme Support for Social Image Cards

### DIFF
--- a/.github/workflows/microservice_socialcards_build_test.yml
+++ b/.github/workflows/microservice_socialcards_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: docker build .
+      run: cd ./microservices/social-cards; docker build .

--- a/microservices/social-cards/README.md
+++ b/microservices/social-cards/README.md
@@ -23,9 +23,21 @@ The following image kinds are supported:
 * default : The generic Social Image Card that is automatically used when sharing the image on the web.
 * iconic : The hidden Social Image Card displaying the Pulsar Mascot.
 
+Also while not yet exposed via the share menu for the Social Image Cards, it is possible to apply themes to the images that will be returned.
+
+Via the `theme=` query parameter on the URL you are able to apply the following themes:
+
+* `light`: The default light theme, that was previously used
+* `github-dark`: A GitHub based Dark Theme, modeled after the same theme available on the Frontend Pulsar Package Website.
+* `dracula`: A Dracula Theme, again modeled after the same theme available on the Frontend Pulsar Package Website.
+
+```
+https://image.pulsar-edit.dev/packages/:packageName?theme=THEME
+```
+
 ## Running Microservice
 * `npm start`: Can be used to start up the server normally.
-* `npm run start:dev`: Exposes a secret API endpoint.`/dev/image/packages/:packageName` will be available when in dev mode, and gives direct access to the HTML code used to display the Social Cards. Using this can allow easier modification and editing of our Social Cards.
+* `npm run start:dev`: Exposes a secret API endpoint.`/dev/packages/:packageName` will be available when in dev mode, and gives direct access to the HTML code used to display the Social Cards. Using this can allow easier modification and editing of our Social Cards. A warning, themes are not yet supported on the special development endpoint.
 
 ## Add New Social Image Cards
 

--- a/microservices/social-cards/index.js
+++ b/microservices/social-cards/index.js
@@ -7,13 +7,14 @@ const apiurl = process.env.APIURL || "https://api.pulsar-edit.dev";
 
 app.get("/packages/:packageName", async (req, res) => {
   let params = {
-    kind: utils.query(req)
+    kind: utils.queryKind(req),
+    theme: utils.queryTheme(req)
   };
 
   try {
 
     let api = await superagent.get(`${apiurl}/api/packages/${decodeURIComponent(req.params.packageName)}`).query(req.query);
-    let img = await utils.generateImage(api.body, params.kind);
+    let img = await utils.generateImage(api.body, params.kind, params.theme);
     res.status(200).setHeader('Content-Type', 'image/png').end(img);
     console.log(`Served Social Image Card: ${params.kind} for ${req.params.packageName}`);
 
@@ -25,7 +26,8 @@ app.get("/packages/:packageName", async (req, res) => {
 
 app.get("/dev/packages/:packageName", async (req, res) => {
   let params = {
-    kind: utils.query(req)
+    kind: utils.queryKind(req),
+    theme: utils.queryTheme(req),
   };
 
   if (process.env.PULSAR_STATUS === "dev") {

--- a/microservices/social-cards/template/default/template.css
+++ b/microservices/social-cards/template/default/template.css
@@ -116,11 +116,6 @@ body[theme="dracula"] {
   color: var(--icon-color);
 }
 
-.downloads .desc {
-  display: block;
-  color: var(--icon-color);
-}
-
 .stars {
   padding: 0px 16px 0px 16px;
   display: inline-block;
@@ -128,20 +123,10 @@ body[theme="dracula"] {
   color: var(--icon-color);
 }
 
-/*.stars .desc {
-  display: block;
-  color: var(--icon-color);
-}*/
-
 .license {
   padding: 0px 120px 0px 16px;
   display: inline-block;
   border-left: 2px solid var(--icon-separator-color);
-  color: var(--icon-color);
-}
-
-.license .desc {
-  display: block;
   color: var(--icon-color);
 }
 

--- a/microservices/social-cards/template/default/template.css
+++ b/microservices/social-cards/template/default/template.css
@@ -1,64 +1,109 @@
+:root {
+  --title-text-color: black;
+  --canvas: white;
+  --link-text-color: blue;
+  --version-text-color: grey;
+  --description-text-color: black;
+  --icon-separator-color: lightGrey;
+  --icon-color: grey;
+}
+
+body[theme="light"] { /* Default */
+  --title-text-color: black;
+  --canvas: white;
+  --link-text-color: blue;
+  --version-text-color: grey;
+  --description-text-color: black;
+  --icon-separator-color: lightGrey;
+  --icon-color: grey;
+}
+
+body[theme="github-dark"] {
+  --title-text-color: #f0f6fc;
+  --canvas: #0d1117;
+  --link-text-color: #58a6ff;
+  --version-text-color: #8b949e;
+  --description-text-color: #c9d1d9;
+  --icon-separator-color: #161b22;
+  --icon-color: #f0f6fc;
+}
+
+body[theme="dracula"] {
+  --title-text-color: #f8f8f2;
+  --canvas: #282a36;
+  --link-text-color: #bd93f9;
+  --version-text-color: #44475a;
+  --description-text-color: #f8f8f2;
+  --icon-separator-color: rgba(255, 255, 255, 0.1);
+  --icon-color: #44475a;
+}
+
 .container {
-padding: 20px 30px 30px 30px;
-margin: 20px;
-height: 80%;
-align-content: center;
+  padding: 20px 30px 30px 30px;
+  margin: 20px;
+  height: 80%;
+  align-content: center;
+  background-color: var(--canvas);
 }
 
 .heading {
-font-weight: 600;
-font-size: 90px;
-display: flex;
+  font-weight: 600;
+  font-size: 90px;
+  display: flex;
 }
 
 .title {
-color: black;
-font-family: 'Jura', sans-serif;
-padding-bottom: 30px;
-white-space:nowrap;
-overflow: hidden;
-text-overflow: ellipsis;
+  color: var(--title-text-color);
+  font-family: 'Jura', sans-serif;
+  padding-bottom: 30px;
+  white-space:nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .subtitle {
-font-weight: 400;
-font-size: 35px;
-display: flex;
-padding-bottom: 5px;
+  font-weight: 400;
+  font-size: 35px;
+  display: flex;
+  padding-bottom: 5px;
+}
+
+.subtitle svg {
+  fill: var(--icon-color);
 }
 
 .link {
-color: blue;
-text-decoration: underline;
-padding: 0px 10px 0px 20px;
-font-family: 'Jura', sans-serif;
+  color: var(--link-text-color);
+  text-decoration: underline;
+  padding: 0px 10px 0px 20px;
+  font-family: 'Jura', sans-serif;
 }
 
 .version {
-padding-left: 5px;
-color: grey;
-font-family: 'Jura', sans-serif;
+  padding-left: 5px;
+  color: var(--version-text-color);
+  font-family: 'Jura', sans-serif;
 }
 
 .description {
-padding-top: 15px;
-color: black;
-font-size: 40px;
-font-family: 'Jura', sans-serif;
-width: 920px;
-height: 250px;
-overflow: hidden;
+  padding-top: 15px;
+  color: var(--description-text-color);
+  font-size: 40px;
+  font-family: 'Jura', sans-serif;
+  width: 920px;
+  height: 250px;
+  overflow: hidden;
 }
 
 .bottom-icons {
-display: inline-block;
-padding: 50px 0px 15px 5px;
-text-align: justify;
-font-size: 40px;
-font-family: 'Jura', sans-serif;
-position: absolute;
-bottom: 20px;
-left: 30px;
+  display: inline-block;
+  padding: 50px 0px 15px 5px;
+  text-align: justify;
+  font-size: 40px;
+  font-family: 'Jura', sans-serif;
+  position: absolute;
+  bottom: 20px;
+  left: 30px;
 }
 
 .bottom-icons > div > svg {
@@ -66,35 +111,38 @@ left: 30px;
 }
 
 .downloads {
-padding: 0px 16px 0px 16px;;
-display: inline-block;
+  padding: 0px 16px 0px 16px;;
+  display: inline-block;
+  color: var(--icon-color);
 }
 
 .downloads .desc {
-display: block;
-color: grey;
+  display: block;
+  color: var(--icon-color);
 }
 
 .stars {
-padding: 0px 16px 0px 16px;
-display: inline-block;
-border-left: 2px solid lightGrey;
+  padding: 0px 16px 0px 16px;
+  display: inline-block;
+  border-left: 2px solid var(--icon-separator-color);
+  color: var(--icon-color);
 }
 
-.stars .desc {
-display: block;
-color: grey;
-}
+/*.stars .desc {
+  display: block;
+  color: var(--icon-color);
+}*/
 
 .license {
-padding: 0px 120px 0px 16px;
-display: inline-block;
-border-left: 2px solid lightGrey;
+  padding: 0px 120px 0px 16px;
+  display: inline-block;
+  border-left: 2px solid var(--icon-separator-color);
+  color: var(--icon-color);
 }
 
 .license .desc {
-display: block;
-color: grey;
+  display: block;
+  color: var(--icon-color);
 }
 
 .pulsar-logo {

--- a/microservices/social-cards/template/default/template.ejs
+++ b/microservices/social-cards/template/default/template.ejs
@@ -19,7 +19,7 @@
   <meta charset="utf-8">
   <title>Generated Image</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <body class="container">
+  <body class="container" theme="">
     <div class="heading">
       <div class="title">
         <%=obj.name%>

--- a/microservices/social-cards/template/iconic-mascot/template.css
+++ b/microservices/social-cards/template/iconic-mascot/template.css
@@ -75,31 +75,16 @@ padding: 0px 16px 0px 16px;;
 display: inline-block;
 }
 
-.downloads .desc {
-display: block;
-color: grey;
-}
-
 .stars {
 padding: 0px 16px 0px 16px;
 display: inline-block;
 border-left: 2px solid lightGrey;
 }
 
-.stars .desc {
-display: block;
-color: grey;
-}
-
 .license {
 padding: 0px 120px 0px 16px;
 display: inline-block;
 border-left: 2px solid lightGrey;
-}
-
-.license .desc {
-display: block;
-color: grey;
 }
 
 .pulsar-logo {

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -33,6 +33,11 @@ async function fullListingPage(req, res, timecop) {
 
 async function singlePackageListing(req, res, timecop) {
   timecop.start("api-request");
+
+  // See if there are any query parameters we want to pass to our OG images.
+  let og_image_kind = req.query.image_kind ?? "default";
+  let og_image_theme = req.query.theme ?? "light";
+
   try {
     let api = await superagent.get(`${apiurl}/api/packages/${decodeURIComponent(req.params.packageName)}`).query(req.query);
     timecop.end("api-request");
@@ -43,7 +48,7 @@ async function singlePackageListing(req, res, timecop) {
       name: obj.name,
       og_url: `https://web.pulsar-edit.dev/packages/${obj.name}`,
       og_description: obj.description,
-      og_image: `https://image.pulsar-edit.dev/packages/${obj.name}`,
+      og_image: `https://image.pulsar-edit.dev/packages/${obj.name}?image_kind=${og_image_kind}&theme=${og_image_theme}`,
       og_image_type: "image/png",
       og_image_width: 1200,
       og_image_height: 600,

--- a/src/site.css
+++ b/src/site.css
@@ -21,9 +21,9 @@ body[theme="github-dark"] {
 }
 
 body[theme="dracula"] {
-  --canvas: #282a36	;
-  --primary: #bd93f9	;
-  --accent: #44475a	;
+  --canvas: #282a36;
+  --primary: #bd93f9;
+  --accent: #44475a;
   --secondary: rgba(255, 255, 255, 0.1);
   --text: #f8f8f2;
   --header-text: var(--text);


### PR DESCRIPTION
This PR allows a bit more customization in the social image cards, Themes!

Currently the following themes are supported on the `default` social image card:

* `light`: The Default
* `github-dark`: Modeled after the same theme on the website
* `dracula`: Modeled after the same theme on the website

Themes are exposed via the `theme` query parameter when requesting the an image.

Additionally this PR adds support for pass through supported query parameters to the OG image cards when sharing a package page.

That last bit means if I want to send someone a link of the Pulsar Package, but also want to make sure that a certain theme, or image kind is applied when doing so, but also want to make sure the user can click the link to visit the website I can send them a link like so:

`https://web.pulsar-edit.dev/packages/atom-clock?theme=github-dark`

And the `github-dark` theme will be applied to the OG image that displays on whatever service I'm sending the image through.

The relevant information has been updated in the readme for social images as well.

---

Also a quick preview of these changes:

### Light: (Basically no change, except fixed the styling of image colors)

![image](https://user-images.githubusercontent.com/26921489/226219392-bd3dd2fb-be2d-466a-8716-0a46c1a4ed78.png)

### Github-Dark

![image](https://user-images.githubusercontent.com/26921489/226219407-4869cfa4-7d6a-4bbc-aeb9-84a84fe99447.png)

### Dracula

![image](https://user-images.githubusercontent.com/26921489/226219419-c5e4ba36-9456-4100-8e91-24c5eeae381d.png)
