### PR TITLE
Add Badge Feature

### DIFF
--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -16,8 +16,7 @@
           <%=badge.title%>
         <% } %>
       </span>
-    <% } %>
-    <% if (badge.type === "success") { %>
+    <% } else if (badge.type === "success") { %>
       <span class="badge badge-success">
         <i class="fas fa-circle-check"></i>
         <% if (typeof badge.text === "string") { %>
@@ -26,10 +25,17 @@
           <%=badge.title%>
         <% } %>
       </span>
-    <% } %>
-    <% if (badge.type === "info") { %>
+    <% } else if (badge.type === "info") { %>
       <span class="badge badge-info">
         <i class="fas fa-circle-info"></i>
+        <% if (typeof badge.text === "string") { %>
+          <%=badge.title%>: <span class="badge-expandable">...</span><span class="badge-text"> <%=badge.text%></span>
+        <% } else { %>
+          <%=badge.title%>
+        <% } %>
+      </span>
+    <% } else { %>
+      <span class="badge">
         <% if (typeof badge.text === "string") { %>
           <%=badge.title%>: <span class="badge-expandable">...</span><span class="badge-text"> <%=badge.text%></span>
         <% } else { %>

--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -1,5 +1,49 @@
 <div class="w-full border border-secondary rounded p-3">
   <a href="/packages/<%=pack.name%>" class="text-3xl text-primary"><%=pack.name%></a>
+
+  <% for (const badge of pack.badges) { %>
+
+    <% if (typeof badge.link === "string") { %>
+      <a href="<%=badge.link%>">
+    <% } %>
+
+    <% if (badge.type === "warn") { %>
+      <span class="badge badge-warn">
+        <i class="fas fa-triangle-exclamation"></i>
+        <% if (typeof badge.text === "string") { %>
+          <%=badge.title%>: <span class="badge-expandable">...</span><span class="badge-text"> <%=badge.text%></span>
+        <% } else { %>
+          <%=badge.title%>
+        <% } %>
+      </span>
+    <% } %>
+    <% if (badge.type === "success") { %>
+      <span class="badge badge-success">
+        <i class="fas fa-circle-check"></i>
+        <% if (typeof badge.text === "string") { %>
+          <%=badge.title%>: <span class="badge-expandable">...</span><span class="badge-text"> <%=badge.text%></span>
+        <% } else { %>
+          <%=badge.title%>
+        <% } %>
+      </span>
+    <% } %>
+    <% if (badge.type === "info") { %>
+      <span class="badge badge-info">
+        <i class="fas fa-circle-info"></i>
+        <% if (typeof badge.text === "string") { %>
+          <%=badge.title%>: <span class="badge-expandable">...</span><span class="badge-text"> <%=badge.text%></span>
+        <% } else { %>
+          <%=badge.title%>
+        <% } %>
+      </span>
+    <% } %>
+
+    <% if (typeof badge.link === "string") { %>
+      </a>
+    <% } %>
+
+  <% } %>
+
   <p class="text-sm opacity-70 min-h-[80px] py-3"><%=pack.description%></p>
   <div class="md:flex sm:flex-col md:flex-row gap-3">
     <div class="md:flex items-center justify-between bg-secondary p-3 rounded flex-1">

--- a/src/site.css
+++ b/src/site.css
@@ -33,6 +33,7 @@ body[theme="github-dark"] {
 
   --badge-default-text: var(--text);
   --badge-default-bg: var(--canvas);
+  /* TODO: Add other badge styling specific to this theme */
 }
 
 body[theme="dracula"] {
@@ -45,6 +46,7 @@ body[theme="dracula"] {
 
   --badge-default-text: var(--text);
   --badge-default-bg: var(--canvas);
+  /* TODO: Add other badge styling specific to this theme */
 }
 
 body[theme="one-dark"] {
@@ -57,6 +59,7 @@ body[theme="one-dark"] {
 
   --badge-default-text: var(--text);
   --badge-default-bg: var(--canvas);
+  /* TODO: Add other badge styling specific to this theme */
 }
 
 body[theme="one-light"] {
@@ -69,6 +72,7 @@ body[theme="one-light"] {
 
   --badge-default-text: var(--text);
   --badge-default-bg: var(--canvas);
+  /* TODO: Add other badge styling specific to this theme */
 }
 
 /**************************/

--- a/src/site.css
+++ b/src/site.css
@@ -9,6 +9,18 @@
   --secondary: rgba(0, 0, 0, 0.1); /* Colours borders and modals */
   --text: #000; /* Colours most text */
   --header-text: #fff; /* Colours header text. Will fall back to `--text` if empty */
+
+  --badge-default-text: var(--text);
+  --badge-default-bg: var(--canvas);
+
+  --badge-warn-text: var(--text);
+  --badge-warn-bg: #dc3545;
+
+  --badge-info-text: var(--text);
+  --badge-info-bg: #17a2b8;
+
+  --badge-success-text: var(--text);
+  --badge-success-bg: #28a745;
 }
 
 body[theme="github-dark"] {
@@ -18,6 +30,9 @@ body[theme="github-dark"] {
   --secondary: rgba(255, 255, 255, 0.1);
   --text: #c9d1d9;
   --header-text: var(--text);
+
+  --badge-default-text: var(--text);
+  --badge-default-bg: var(--canvas);
 }
 
 body[theme="dracula"] {
@@ -27,6 +42,9 @@ body[theme="dracula"] {
   --secondary: rgba(255, 255, 255, 0.1);
   --text: #f8f8f2;
   --header-text: var(--text);
+
+  --badge-default-text: var(--text);
+  --badge-default-bg: var(--canvas);
 }
 
 body[theme="one-dark"] {
@@ -36,6 +54,9 @@ body[theme="one-dark"] {
   --secondary: #181a1f;
   --text: #abb2bf;
   --header-text: var(--text);
+
+  --badge-default-text: var(--text);
+  --badge-default-bg: var(--canvas);
 }
 
 body[theme="one-light"] {
@@ -45,6 +66,9 @@ body[theme="one-light"] {
   --secondary: #c5cad3; /* Pulsar's @base-border-color */
   --text: #2c313a; /* Pulsar's @text-color */
   --header-text: #121417; /* Pulsar's @text-color-highlight */
+
+  --badge-default-text: var(--text);
+  --badge-default-bg: var(--canvas);
 }
 
 /**************************/
@@ -95,6 +119,48 @@ footer i {
 
 footer a {
   @apply block text-sm my-1 text-primary hover:opacity-80 transition-all;
+}
+
+/**************************/
+/******** BADGES **********/
+/**************************/
+
+.badge {
+  @apply text-xs font-medium mr-2 px-2.5 py-0.5 rounded-full;
+  color: var(--badge-default-text);
+  background-color: var(--badge-default-bg);
+  vertical-align: text-top;
+}
+
+.badge.badge-warn {
+  color: var(--badge-warn-text);
+  background-color: var(--badge-warn-bg);
+}
+
+.badge.badge-info {
+  color: var(--badge-info-text);
+  background-color: var(--badge-info-bg);
+}
+
+.badge.badge-success {
+  color: var(--badge-success-text);
+  background-color: var(--badge-success-bg);
+}
+
+.badge:hover .badge-text {
+  display: contents;
+}
+
+.badge:hover .badge-expandable {
+  display: none;
+}
+
+.badge-expandable {
+  display: contents;
+}
+
+.badge-text {
+  display: none;
 }
 
 /**************************/

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,8 @@ function prepareForListing(obj) {
         pack.stars = Number(pack.stars).toLocaleString();
         pack.downloads = Number(pack.downloads).toLocaleString();
 
+        pack.badges = obj[i].badges ?? [];
+
         packList.push(pack);
       } catch(err) {
         console.log(err);
@@ -164,6 +166,8 @@ function prepareForDetail(obj) {
         iconic: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=iconic)](https://web.pulsar-edit.dev/packages/${pack.name})`
       }
     };
+
+    pack.badges = obj.badges ?? [];
 
     resolve(pack);
   });


### PR DESCRIPTION
This PR adds the ability to add and view badges on the frontend.

This PR is in compliance with the spec proposed over on the [backend](https://github.com/pulsar-edit/package-backend/pull/131) where we can handle an array of badges, each of which with optional links, and text details. While keeping the required type and title.

In it we have support for all badge types, applying coloring and icons as needed. These new colors have been added to the theme, only adding the default badge data to each theme, to ensure they are always visible (In case we add a new badge type that is not yet supported by the website).

Additionally, our badges on the frontend are contextually compact. Where by default only displaying the title and `...` to indicate if they have a `text` field. And on hover, if they do have a `text` field the `...` is removed, and replaced by the additional text.

Below are some examples of this data in use:

![image](https://user-images.githubusercontent.com/26921489/226786111-4aab3962-6e2f-4cac-b831-496646cb7f43.png)

![pulsar-badge-test-2](https://user-images.githubusercontent.com/26921489/226786285-cc94c964-a1dd-4a88-811d-17f31f83e9cf.gif)
