### PR TITLE
Improve Data Exposed on Container Images

### DIFF
--- a/.github/workflows/microservice_authstate_build_test.yml
+++ b/.github/workflows/microservice_authstate_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: docker build .
+      run: cd ./microservice/auth-state-cleanup; docker build .

--- a/.github/workflows/microservice_authstate_build_test.yml
+++ b/.github/workflows/microservice_authstate_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: cd ./microservice/auth-state-cleanup; docker build .
+      run: cd ./microservices/auth-state-cleanup; docker build .

--- a/.github/workflows/microservice_download_build_test.yml
+++ b/.github/workflows/microservice_download_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: cd ./microservice/download; docker build .
+      run: cd ./microservices/download; docker build .

--- a/.github/workflows/microservice_download_build_test.yml
+++ b/.github/workflows/microservice_download_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: docker build .
+      run: cd ./microservice/download; docker build .

--- a/.github/workflows/microservice_webhooks_build_test.yml
+++ b/.github/workflows/microservice_webhooks_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: cd ./microservice/webhooks; docker build .
+      run: cd ./microservices/webhooks; docker build .

--- a/.github/workflows/microservice_webhooks_build_test.yml
+++ b/.github/workflows/microservice_webhooks_build_test.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build Docker Image
-      run: docker build .
+      run: cd ./microservice/webhooks; docker build .

--- a/microservices/auth-state-cleanup/Dockerfile
+++ b/microservices/auth-state-cleanup/Dockerfile
@@ -4,9 +4,11 @@ FROM node:18-slim
 # Below we use Dockerfile Labels w/ predefined annotation keys to properly link to arbitrary
 # container images to the proper Pulsar Repo.
 LABEL org.opencontainers.artifact.description="Microservice to Cleanup our Database AuthState Table"
-LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend"
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend/tree/main/microservices/auth-state-cleanup"
 LABEL org.opencontainers.image.author="confused-Techie"
 LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.description="Microservice to Cleanup our Database AuthState Table"
+LABEL org.opencontainers.image.documentation="https://github.com/pulsar-edit/package-frontend/blob/main/microservices/auth-state-cleanup/README.md"
 LABEL description="Microservice to Cleanup our Database AuthState Table"
 
 # Create and change to the app directory

--- a/microservices/download/Dockerfile
+++ b/microservices/download/Dockerfile
@@ -4,9 +4,11 @@ FROM node:18-slim
 # Below we use Dockerfile Labels w/ predefined annotation keys to properly link arbitrary
 # container images to the proper Pulsar Repo.
 LABEL org.opencontainers.artifact.description="Download URL Microservice for Pulsar Package Frontend"
-LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend"
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend/tree/main/microservices/download"
 LABEL org.opencontainers.image.author="confused-Techie"
 LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.description="Download URL Microservice for Pulsar Package Frontend"
+LABEL org.opencontainers.image.documentation="https://github.com/pulsar-edit/package-frontend/blob/main/microservices/download/README.md"
 LABEL description="Download URL Microservice for Pulsar Package Frontend"
 
 # Create and change to the app directory

--- a/microservices/social-cards/Dockerfile
+++ b/microservices/social-cards/Dockerfile
@@ -3,9 +3,11 @@ FROM node:18-slim
 
 # Below we use Dockerfile Labels w/ Pre-defined annotation keys to properly
 # link arbitrary container images to the proper Pulsar Repo.
-LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend"
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend/tree/main/microservices/social-cards"
 LABEL org.opencontainers.artifact.description="Social Image Card Microservice for Pulsar Package Frontend"
 LABEL description="Social Image Card Microservice for Pulsar Package Frontend"
+LABEL org.opencontainers.image.description="Social Image Card Microservice for Pulsar Package Frontend"
+LABEL org.opencontainers.image.documentation="https://github.com/pulsar-edit/package-frontend/blob/main/microservices/social-cards/README.md"
 LABEL org.opencontainers.image.authors="confused-Techie"
 LABEL org.opencontainers.image.license="MIT"
 

--- a/microservices/webhooks/Dockerfile
+++ b/microservices/webhooks/Dockerfile
@@ -4,9 +4,10 @@ FROM node:18-slim
 # Below we use Dockerfile Labels w/ predefined annotation keys to properly link arbitrary
 # container images to the proper Pulsar Repo.
 LABEL org.opencontainers.artifact.description="Microservice to handle custom webhooks for Pulsar-Edit"
-LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend"
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend/tree/main/microservices/webhooks"
 LABEL org.opencontainers.image.author="confused-Techie"
 LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.documentation="https://github.com/pulsar-edit/package-frontend/blob/main/microservices/webhooks/README.md"
 LABEL org.opencontainers.image.description="Microservice to handle custom webhooks for Pulsar-Edit"
 LABEL description="Microservice to handle custom webhooks for Pulsar-Edit"
 


### PR DESCRIPTION
This PR adds additional metadata to our containers, by updating the `source` URL, as well as adding a `documentation` URL, and putting the `description` somewhere compatible with GitHub.

These changes result in zero code changes, but improve visibility of the container details depending on the application used to view them.