### PR TITLE
Update file ending of Windows Portable

### DIFF
--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -245,7 +245,7 @@ async function findLink(os, type) {
         binaryPath = findBinary("binaries/Pulsar Setup", "start", taskGraph.data.task.artifacts[0].files);
         break;
       case "windows_portable":
-        binaryPath = findBinary(".exe", "end", taskGraph.data.task.artifacts[0].files);
+        binaryPath = findBinary(".zip", "end", taskGraph.data.task.artifacts[0].files);
         break;
       case "windows_blockmap":
         binaryPath = findBinary(".exe.blockmap", "end", taskGraph.data.task.artifacts[0].files);


### PR DESCRIPTION
This PR fixes the expected file ending of the windows portable binary file, since it's been changed from a self extracting `.exe` binary to a proper `.zip` binary, the download microservice couldn't find it, and instead just returned the setup binary, which honestly now looking at this code I'm surprised didn't happen more often before.