### PR TITLE
Package's Readme Link Overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "cross-env": "^7.0.3",
         "jest": "^29.2.2",
         "nodemon": "^2.0.20"
+      },
+      "engines": {
+        "node": ">=16 <=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/reg.js
+++ b/src/reg.js
@@ -7,7 +7,8 @@ const matches = {
   },
   author: {
     compact: new RegExp(/^(.*)\s\<(.*)\>\s\((.*)\)$/),
-    optional_compact: new RegExp(/^(?:([^<(]*)\s){0,1}(?:\<([^>(]*)\>\s){0,1}(?:\(([^)]*)\)){0,1}$/)
+    // Keep in mind `optional_compact` the name group[1] needs to be trimmed as it's whitespace inclusive
+    optional_compact: new RegExp(/^(?:([^<(]*)){0,1}(?:\s*\<([^>(]*)\>){0,1}(?:\s*\(([^)]*)\)){0,1}$/)
   },
   localLinks: {
     currentDir: new RegExp(/^\.\//),

--- a/src/reg.js
+++ b/src/reg.js
@@ -17,7 +17,8 @@ const matches = {
     rootDir: new RegExp(/^\//)
   },
   atomLinks: {
-    package: new RegExp(/^https:\/\/atom\.io\/packages\/(.*)$/)
+    package: new RegExp(/^https:\/\/atom\.io\/packages\/(.*)$/),
+    flightManual: new RegExp(/^https:\/\/flight-manual\.atom\.io\//)
   }
 };
 

--- a/src/reg.js
+++ b/src/reg.js
@@ -3,7 +3,9 @@
 const matches = {
   repoLink: {
     standard: new RegExp(/^https\:\/\/github\.com\/(\S*)\/(\S*)$/),
-    protocol: new RegExp(/^git\@github\.com\:(\S*)\/(\S*)(\.git)?$/)
+    protocol: new RegExp(/^git\@github\.com\:(\S*)\/(\S*)(\.git)?$/),
+    githubAssumedShorthand: new RegExp(/^[a-zA-Z0-9-_\.]+\/[a-zA-Z0-9-_\.]+$/),
+    githubShorthand: new RegExp(/^github:([a-zA-Z0-9-_\.]+\/[a-zA-Z0-9-_\.]+)$/)
   },
   author: {
     compact: new RegExp(/^(.*)\s\<(.*)\>\s\((.*)\)$/),

--- a/src/reg.js
+++ b/src/reg.js
@@ -13,6 +13,9 @@ const matches = {
   localLinks: {
     currentDir: new RegExp(/^\.\//),
     rootDir: new RegExp(/^\//)
+  },
+  atomLinks: {
+    package: new RegExp(/^https:\/\/atom\.io\/packages\/(.*)$/)
   }
 };
 

--- a/src/reg.js
+++ b/src/reg.js
@@ -6,7 +6,8 @@ const matches = {
     protocol: new RegExp(/^git\@github\.com\:(\S*)\/(\S*)(\.git)?$/)
   },
   author: {
-    compact: new RegExp(/^(.*)\s\<(.*)\>\s\((.*)\)$/)
+    compact: new RegExp(/^(.*)\s\<(.*)\>\s\((.*)\)$/),
+    optional_compact: new RegExp(/^(?:([^<(]*)\s){0,1}(?:\<([^>(]*)\>\s){0,1}(?:\(([^)]*)\)){0,1}$/)
   },
   localLinks: {
     currentDir: new RegExp(/^\.\//),

--- a/src/tests/reg.test.js
+++ b/src/tests/reg.test.js
@@ -28,6 +28,16 @@ let suites = {
       "<dev@lhbasics.com>",
       "(https://pulsar-edit.dev)"
     ]
+  },
+  authorOptionalCompact: {
+    valid: [
+      "confused-Techie (https://pulsar-edit.dev)",
+      "confused-Techie <dev@lhbasics.dev>",
+      "<dev@lhbasics.dev> (https://pulsar-edit.dev)"
+    ],
+    invalid: [
+      "confused-Techie (https://pulsar-edit.dev) <dev@lhbasics.dev>"
+    ]
   }
 }
 
@@ -133,5 +143,41 @@ describe("Compact Author Field", () => {
     expect(res[1]).toBe("confused-Techie");
     expect(res[2]).toBe("dev@lhbasics.com");
     expect(res[3]).toBe("https://pulsar-edit.dev");
+  })
+});
+
+describe("Optional Compact Author Field", () => {
+  describe("Returns true `.test()` of Valid Data", () => {
+    for (let i = 0; i < suites.authorOptionalCompact.valid.length; i++) {
+      test(`${suites.authorOptionalCompact.valid[i]} - reg.author.optional_compact.test()`, () => {
+        expect(reg.author.optional_compact.test(
+          suites.authorOptionalCompact.valid[i]
+        )).toBeTruthy();
+      });
+    }
+  });
+
+  describe("Returns false `.test()` of Invalid Data", () => {
+    for (let i = 0; i < suites.authorOptionalCompact.invalid.length; i++) {
+      test(`${suites.authorOptionalCompact.invalid[i]} - reg.author.optional_compact.test()`, () => {
+        expect(reg.author.optional_compact.test(
+          suites.authorOptionalCompact.invalid[i]
+        )).toBeFalsy();
+      });
+    }
+  });
+
+  test("Returns Expected Data from Matches", () => {
+    let res1 = suites.authorOptionalCompact.valid[0].match(reg.author.optional_compact);
+    expect(res1[1].trim()).toBe("confused-Techie");
+    expect(res1[3]).toBe("https://pulsar-edit.dev");
+
+    let res2 = suites.authorOptionalCompact.valid[1].match(reg.author.optional_compact);
+    expect(res2[1].trim()).toBe("confused-Techie");
+    expect(res2[2]).toBe("dev@lhbasics.dev");
+
+    let res3 = suites.authorOptionalCompact.valid[2].match(reg.author.optional_compact);
+    expect(res3[2]).toBe("dev@lhbasics.dev");
+    expect(res3[3]).toBe("https://pulsar-edit.dev");
   })
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,7 +181,7 @@ function findAuthorField(obj) {
     if (reg.author.optional_compact.test(obj.metadata.author)) {
       // It matches, so we know we have to parse it
       let constru = obj.metadata.author.match(reg.author.optional_compact);
-      author = constru[1];
+      author = constru[1].trim();
     } else {
       // It doesn't match, and we will assume it's a basic author field.
       author = obj.metadata.author;

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,15 +178,14 @@ function findAuthorField(obj) {
   if (typeof obj.metadata.author === "string") {
 
     // We know this is not an object, but we must ensure this isn't a compressed author object.
-    if (reg.author.compact.test(obj.metadata.author)) {
+    if (reg.author.optional_compact.test(obj.metadata.author)) {
       // It matches, so we know we have to parse it
-      let constru = obj.metadata.author.match(reg.author.compact);
+      let constru = obj.metadata.author.match(reg.author.optional_compact);
       author = constru[1];
     } else {
       // It doesn't match, and we will assume it's a basic author field.
       author = obj.metadata.author;
     }
-    author = obj.metadata.author;
   } else if (typeof obj.metadata.author === "object" && obj.metadata.author.hasOwnProperty("name")) {
     author = obj.metadata.author.name;
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -259,6 +259,10 @@ function findRepoField(obj) {
     // Git Protocol Defined. Create normalized link.
     let constru = repo.match(reg.repoLink.protocol);
     return `https://github.com/${constru[1]}/${constru[2].replace(".git","")}`;
+  } else if (reg.repoLink.githubAssumedShorthand.test(repo)) {
+    return `https://github.com/${repo.match(reg.repoLink.githubAssumedShorthand)[0]}`;
+  } else if (reg.repoLink.githubShorthand.test(repo)) {
+    return `https://github.com/${repo.match(reg.repoLink.githubShorthand)[1]}`;
   } else {
     // We couldn't determine what to do here. Just return.
     return repo;

--- a/src/utils.js
+++ b/src/utils.js
@@ -182,6 +182,9 @@ function prepareForDetail(obj) {
                     let tmpLink = link.replace(".git", "");
                     attr[1] = `${cleanRepo}/raw/HEAD/${tmpLink}`;
 
+                  } else if (reg.atomLinks.flightManual.test(link)) {
+                    // Resolve any links to the flight manual to web archive
+                    attr[1] = link.replace(reg.atomLinks.flightManual, "https://web.archive.org/web/20221215003438/https://flight-manual.atom.io/");
                   }
                 }
               });


### PR DESCRIPTION
Alright, so in response to a few issues that have been piling up, I've finally gotten around to the linking overhaul that's been badly needed.

In this PR I've addressed several issues that relate to links within community package's readme's.

The major ability added in this PR is that we are now easily able to modify any links within a readme, to fix them as needed. But otherwise here's a list of what's new in this PR

* Properly supports shorthand string author assignment within the `author` field of a `package.json`
* Resolves any links pointing to `https://atom.io/packages/...` => `https://web.pulsar-edit.dev/packages/...`
* Supports both GitHub Shorthand within the `repository` field of the `package.json` and GitHub assumed shorthand. As these are both valid repo declarations according to NPM 
* Additionally resolves any links pointing to `https://flight-manual.atom.io/` to point to the Web Archive of the Flight Manual, while keeping the rest of the link to still resolve properly.
* Like we already do for images, any local, or current directory links found within a page, are resolved against the GitHub repo of the package, such as `./LICENSE.md` => `https://github.com/pulsar-edit/package-frontend/LICENSE.md`

Feel free to provide any feedback as felt needed, otherwise this, and other approved PRs will be hopefully merged soon and the updates pushed to prod.

---

Resolves #35 
Resolves #95 
Resolves #92 