### PR TITLE
Add optional chaining on `.trim()`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -226,7 +226,7 @@ function findAuthorField(obj) {
     if (reg.author.optional_compact.test(obj.metadata.author)) {
       // It matches, so we know we have to parse it
       let constru = obj.metadata.author.match(reg.author.optional_compact);
-      author = constru[1].trim();
+      author = constru[1]?.trim();
     } else {
       // It doesn't match, and we will assume it's a basic author field.
       author = obj.metadata.author;


### PR DESCRIPTION
This PR adds optional chaining to a string based method being called on the author field.

When a package has `author: ""` set, the regex to match the author field will pass, as every component is optional, but since the string has zero length a `trim()` call will fail.

One such package is `teletype`, which when navigating to `/packages` or preforming an empty search, since it has one of the highest download counts of any package it would always be on the first page of results, causing those pages to error out.

Resolves #97 
Resolves #98 