### PR TITLE
Override img block

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,7 @@ module.exports = {
             h4: { color: 'var(--text)' },
             h5: { color: 'var(--text)' },
             h6: { color: 'var(--text)' },
+            img: { display: 'inline'},
           }
         }
       }


### PR DESCRIPTION
By default tailwind uses this style for images (and other objects):

```css
img,
...
object {
  display: block;
  vertical-align: middle;
}
```

Which is probably fine when talking about html pages but it causes a disparity between our package frontend and how GH and Pulsar render images in markdown READMEs:

![image](https://user-images.githubusercontent.com/58074586/236262934-8dd0ca15-324e-4c54-b2a5-7f8489df2b84.png)

See conversation on discord - https://discordapp.com/channels/992103415163396136/992275353961775145/1103705876944125983

This change reverts the default style for `<img>` to display in a block vs inline.

You can still display in blocks using proper markdown styles.
e.g.
```md
![img1](./img1.png)
![img2](./img2.png)
```
Should be rendered inline within a single `<p>` whereas:
```md
![img1](./img1.png)

![img2](./img2.png)
```
Should render in a block as would be in their own `<p>` elements which naturally display as block.