### PR TITLE
Fix badge wrap in FireFox

### DIFF
--- a/src/site.css
+++ b/src/site.css
@@ -135,6 +135,7 @@ footer a {
   background-color: var(--badge-default-bg);
   vertical-align: text-top;
   white-space: nowrap;
+  display: inline-block;
 }
 
 .badge.badge-warn {


### PR DESCRIPTION
As discussed over on #102 the previous fix for badge wrap issues worked fine on Chromium based browsers, but still had some issues on FireFox.

This new fix resolves the issues in FireFox, while leaving things unchanged otherwise, allowing both browsers to be properly fixed.

Although this PR doesn't totally address the spacing issue that has been found between a badge and the package title