### PR TITLE
Remove Pagination on Empty Return

### DIFF
--- a/ejs-views/pages/search.ejs
+++ b/ejs-views/pages/search.ejs
@@ -4,7 +4,10 @@
   <%- include('../partials/search_bar'); %>
   <%- include('../partials/pagination'); %>
   <%- include('../partials/package_grid', { packages }); %>
-  <%- include('../partials/pagination'); %>
+  <% if (locals.pagination.length > 1) { %>
+    <% // We only want to show pagination twice, if pagination is present %>
+    <%- include('../partials/pagination'); %>
+  <% } %>
 </article>
 
 <%- include('../partials/footer'); %>

--- a/ejs-views/pages/search.ejs
+++ b/ejs-views/pages/search.ejs
@@ -4,7 +4,7 @@
   <%- include('../partials/search_bar'); %>
   <%- include('../partials/pagination'); %>
   <%- include('../partials/package_grid', { packages }); %>
-  <% if (locals.pagination.length > 1) { %>
+  <% if (locals.pagination && locals.pagination.length > 1) { %>
     <% // We only want to show pagination twice, if pagination is present %>
     <%- include('../partials/pagination'); %>
   <% } %>

--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,4 +1,4 @@
-<% if (locals.pagination) { %>
+<% if (locals.pagination && locals.pagination.length > 1) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
         <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
         <div class="flex items-center gap-1 sm:gap-3 lg:gap-6">
@@ -25,4 +25,8 @@
             </a>
         </div>
     </div>
+<% } else { %>
+  <div class="text-center">
+    <h4>No packages found matching these parameters.</h4>
+  </div>
 <% } %>


### PR DESCRIPTION
This PR removes the pagination UI, when the results of whatever request are empty.

Resolves #104 

## Example 

![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/e8b9ad88-95e2-40f2-827e-7593e3a0b8a4)
