### PR TITLE
Create `renovate.json`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "extends": [ "config:base", ":dependencyDashboardApproval"],
+  "constraints": {
+    "node": "< 18"
+  },
+  "labels": ["dependencies"],
+  "separateMajorMinor": "false"
+}


### PR DESCRIPTION
Like the title says, this PR will integrate `renovate` with the frontend, as the many dependences here and within microservices are currently untracked