### PR TITLE
Add `wide` input class

### DIFF
--- a/ejs-views/pages/login.ejs
+++ b/ejs-views/pages/login.ejs
@@ -4,7 +4,7 @@
   <div class="flex-1">
     <h1 class="mb-4">Sign Up with PAT</h1>
     <form action="https://api.pulsar-edit.dev/api/pat">
-      <input type="text" name="token" placeholder="Enter your GitHub PAT">
+      <input class="wide" type="text" name="token" placeholder="Enter your GitHub PAT">
       <button>
         <i class="fas fa-key mr-2"></i>
         Sign Up

--- a/ejs-views/pages/user_page.ejs
+++ b/ejs-views/pages/user_page.ejs
@@ -19,7 +19,7 @@
       type="text"
       disabled
       value="api-token-goes-here"
-      class="bg-secondary copy-to-clipboard-input-js"
+      class="bg-secondary wide copy-to-clipboard-input-js"
     />
     <button class="copy-to-clipboard-button-js">
       <i class="fas fa-clipboard mr-2"></i>

--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -106,7 +106,7 @@
             <i class="fas fa-clipboard mr-2"></i>
             <span>Package Link</span>
           </button>
-          <input type="text" disabled value="<%=pack.share.pageLink%>" class="bg-secondary"/>
+          <input type="text" disabled value="<%=pack.share.pageLink%>" class="bg-secondary wide"/>
         </div>
 
         <div class="flex p-2">
@@ -115,7 +115,7 @@
             <i class="fas fa-clipboard mr-2"></i>
             <span>MarkDown Link</span>
           </button>
-          <input type="text" disabled value="<%=pack.share.mdLink.default%>" class="bg-secondary"/>
+          <input type="text" disabled value="<%=pack.share.mdLink.default%>" class="bg-secondary wide"/>
         </div>
 
         <div class="flex p-2">
@@ -124,7 +124,7 @@
             <i class="fas fa-clipboard mr-2"></i>
             <span>Iconic MarkDown Link</span>
           </button>
-          <input type="text" disabled value="<%=pack.share.mdLink.iconic%>" class="bg-secondary"/>
+          <input type="text" disabled value="<%=pack.share.mdLink.iconic%>" class="bg-secondary wide"/>
         </div>
 
       </div>

--- a/ejs-views/partials/search_bar.ejs
+++ b/ejs-views/partials/search_bar.ejs
@@ -1,7 +1,7 @@
 <div class="text-center">
   <h1>Packages make Pulsar do amazing things.</h1>
   <form class="my-12" action="/packages/search">
-    <input type="search" value="<% if (locals.search) { %><%- search %><% } %>" name="q" placeholder="Search Packages..." />
+    <input class="wide" type="search" value="<% if (locals.search) { %><%- search %><% } %>" name="q" placeholder="Search Packages..." />
     <button type="submit">
       <i class="fas fa-magnifying-glass"></i>
       Search

--- a/src/site.css
+++ b/src/site.css
@@ -96,6 +96,10 @@ h3 {
 }
 
 input {
+  @apply border border-secondary bg-transparent rounded max-w-3xl p-3
+}
+
+input.wide {
   @apply border border-secondary bg-transparent rounded w-2/3 max-w-3xl p-3
 }
 


### PR DESCRIPTION
Seems since we styled the `input` element to be extra wide, which looks great on the search bar, or other input elements, it caused bizarre styling when a package readme contained a task list.

![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/d818c3eb-1100-4227-a45e-df98c43d6589)

With this update, we create a new class, that all existing input element's are now using, meanwhile we left general input elements without this single style.

## After:
![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/ad1b3994-f5d8-4e8c-9a5e-608cb5505b2d)
