### PR TITLE
Handle Bundled Packages

### DIFF
--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -130,11 +130,13 @@
       </div>
     </div>
     <% } %>
-    <a href="<%=pack.install%>" class="hidden sm:flex items-center justify-center mt-3 md:mt-0">
-      <button class="w-full md:w-auto">
-        <i class="fas fa-download mr-2"></i>
-        <span>Install</span>
-      </button>
-    </a>
+    <% if (!pack.isBundled) { %>
+      <a href="<%=pack.install%>" class="hidden sm:flex items-center justify-center mt-3 md:mt-0">
+        <button class="w-full md:w-auto">
+          <i class="fas fa-download mr-2"></i>
+          <span>Install</span>
+        </button>
+      </a>
+    <% } %>
   </div>
 </div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,6 +82,16 @@ function prepareForListing(obj) {
 
         pack.badges = obj[i].badges ?? [];
 
+        // Apply any bundled package logic
+        if (isBundledPackage(pack.name)) {
+          pack.isBundled = true;
+          pack.badges.push({
+            type: "info",
+            title: "Bundled",
+            link: "https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/badge_spec.md#bundled"
+          });
+        }
+
         packList.push(pack);
       } catch(err) {
         console.log(err);
@@ -214,6 +224,16 @@ function prepareForDetail(obj) {
 
     pack.badges = obj.badges ?? [];
 
+    // Apply any bundled package logic
+    if (isBundledPackage(pack.name)) {
+      pack.isBundled = true;
+      pack.badges.push({
+        type: "info",
+        title: "Bundled",
+        link: "https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/badge_spec.md#bundled"
+      });
+    }
+
     resolve(pack);
   });
 }
@@ -336,6 +356,40 @@ function getPagination(req, api) {
       next: page < pages ? getRouteUrl(page + 1) : null,
       last: page < pages ? getRouteUrl(pages) : null,
     }
+  }
+}
+
+function isBundledPackage(name) {
+  // Takes the name of a package and returns true if that package is bundled
+  // within the Pulsar editor
+  const bundledPackages = [
+    "about", "archive-view", "atom-dark-syntax", "atom-dark-ui", "atom-light-syntax",
+    "atom-light-ui", "autocomplete-atom-api", "autocomplete-css", "autocomplete-html",
+    "autocomplete-plus", "autocomplete-snippets", "autoflow", "autosave", "background-tips",
+    "base16-tomorrow-dark-theme", "base16-tomorrow-light-theme", "bookmarks",
+    "bracket-matcher", "command-palette", "dalek", "deprecation-cop", "dev-live-reload",
+    "encoding-selector", "exception-reporting", "find-and-replace", "fuzzy-finder",
+    "git-diff", "go-to-line", "grammar-selector", "image-view", "incompatible-packages",
+    "keybinding-resolver", "language-c", "language-clojure", "language-coffee-script",
+    "language-csharp", "language-css", "language-gfm", "language-git", "language-go",
+    "language-html", "language-hyperlink", "language-java", "language-javascript",
+    "language-json", "language-less", "language-make", "language-mustache",
+    "language-objective-c", "language-perl", "language-php", "language-property-list",
+    "language-python", "language-ruby-on-rails", "language-ruby", "language-rust-bundled",
+    "language-sass", "language-shellscript", "language-source", "language-sql",
+    "language-text", "language-todo", "language-toml", "language-typescript",
+    "language-xml", "language-yaml", "line-ending-selector", "link", "markdown-preview",
+    "notifications", "one-dark-syntax", "one-dark-ui", "one-light-syntax", "one-light-ui",
+    "open-on-github", "package-generator", "settings-view", "solarized-dark-syntax",
+    "solarized-light-syntax", "status-bar", "styleguide", "tabs", "timecop", "tree-view",
+    "update-package-dependencies", "welcome", "whitespace", "wrap-guide",
+    "snippets", "symbols-view", "github", "spell-check"
+  ];
+
+  if (bundledPackages.includes(name)) {
+    return true;
+  } else {
+    return false;
   }
 }
 


### PR DESCRIPTION
This PR addresses [`pulsar-edit/pulsar#353`](https://github.com/pulsar-edit/pulsar/issues/353).

With this PR when the frontend needs to display a bundled, or otherwise a package that is included within Pulsar by default, it will add a badge that says this package is bundled, as well as remove the "Install" button from these packages.

While originally I wanted to add a notice explaining further what this meant, I think with it's current implementation it's really clear enough but we still could implement it if we thought it was needed.

## Example:

![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/7e760b27-f3df-4bcb-86c9-baf4111e627a)

![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/631ef940-fc38-4cf9-a797-6287fbb02305)
