### PR TITLE
Fix Pagination

### DIFF
--- a/ejs-views/pages/search.ejs
+++ b/ejs-views/pages/search.ejs
@@ -4,7 +4,7 @@
   <%- include('../partials/search_bar'); %>
   <%- include('../partials/pagination'); %>
   <%- include('../partials/package_grid', { packages }); %>
-  <% if (pagination && pagination.total > 1) { %>
+  <% if (pagination && pagination.total > 0) { %>
     <% // We only want to show pagination twice, if pagination is present %>
     <%- include('../partials/pagination'); %>
   <% } %>

--- a/ejs-views/pages/search.ejs
+++ b/ejs-views/pages/search.ejs
@@ -4,7 +4,7 @@
   <%- include('../partials/search_bar'); %>
   <%- include('../partials/pagination'); %>
   <%- include('../partials/package_grid', { packages }); %>
-  <% if (locals.pagination && locals.pagination.length > 1) { %>
+  <% if (pagination && pagination.total > 1) { %>
     <% // We only want to show pagination twice, if pagination is present %>
     <%- include('../partials/pagination'); %>
   <% } %>

--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,4 +1,4 @@
-<% if (locals.pagination && locals.pagination.length > 1) { %>
+<% if (pagination && pagination.total > 1) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
         <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
         <div class="flex items-center gap-1 sm:gap-3 lg:gap-6">

--- a/ejs-views/partials/pagination.ejs
+++ b/ejs-views/partials/pagination.ejs
@@ -1,4 +1,4 @@
-<% if (pagination && pagination.total > 1) { %>
+<% if (pagination && pagination.total > 0) { %>
     <div id="pagination" class="sm:flex-row flex-col flex items-center justify-between gap-3 border border-secondary rounded p-3">
         <p class="opacity-70">Showing <%- pagination.from %> to <%- pagination.to %> of <%- pagination.total %> entries</p>
         <div class="flex items-center gap-1 sm:gap-3 lg:gap-6">


### PR DESCRIPTION
Previously in #105 checks were implemented into pagination to ensure that pagination wouldn't show when there was nothing to paginate through, but seems those changes had been checking the incorrect variable resulting in more often than not pagination being disabled, even if results were present.

This PR now resolves the values being checked, and we can confirm the expected behave via the following screenshots:

## With one result:
![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/da152af7-b8b4-4c82-897d-e7cb00dded3b)

## With no results:
![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/55a86816-f034-4bd0-bca0-998a663087d2)

## With many results:

![image](https://github.com/pulsar-edit/package-frontend/assets/26921489/089229ae-1e4f-400b-a1d8-867080485d14)

---

Resolves #111 