### PR TITLE
Resolve Images pointing directly to GitHub repo, rather than to resource

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -163,7 +163,6 @@ function prepareForDetail(obj) {
               token.attrs.forEach((attr) => {
                 if (attr[0] === "href") {
                   let link = attr[1];
-                  console.log(link);
                   if (reg.atomLinks.package.test(link)) {
                     // Fix any links that attempt to point to packages on `https://atom.io/packages/...`
                     attr[1] = `https://web.pulsar-edit.dev/packages/${link.match(reg.atomLinks.package)[1]}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,6 +144,10 @@ function prepareForDetail(obj) {
         let cleanRepo = pack.repoLink.replace(".git", "");
         let rawLink = token.attrGet('src');
         token.attrSet('src', `${cleanRepo}/raw/HEAD/${rawLink}`);
+      } else if ([".gif", ".png", ".jpg", ".jpeg", ".webp"].find(ext => token.attrGet("src").endsWith(ext)) && token.attrGet("src").startsWith("https://github.com") && token.attrGet("src").includes("blob")) {
+        // Should match on any image being distributed from GitHub that's using `blob` instead of `raw` causing images to not load correctly
+        let rawLink = token.attrGet("src");
+        token.attrSet("src", rawLink.replace("blob", "raw"));
       }
 
       // pass token to default renderer.
@@ -159,6 +163,7 @@ function prepareForDetail(obj) {
               token.attrs.forEach((attr) => {
                 if (attr[0] === "href") {
                   let link = attr[1];
+                  console.log(link);
                   if (reg.atomLinks.package.test(link)) {
                     // Fix any links that attempt to point to packages on `https://atom.io/packages/...`
                     attr[1] = `https://web.pulsar-edit.dev/packages/${link.match(reg.atomLinks.package)[1]}`;


### PR DESCRIPTION
Some links for images that users may use within a README, can point to a location in their GitHub page using `blob` instead of `raw` causing the HTTP page to be loaded rather than the raw image. To resolve this several solutions where considered but ultimately what I've gone with:

* If an image with a link ends in one of the following file types:
   * ".gif"
   * ".png"
   * ".jpg"
   * ".jpeg"
   * ".webp"
* As well as it begins with `https://github.com` 
* As well as includes `blob`

Then the `blob` within the link will be swapped out for `raw` instead. Hopefully resolving the image within, or at the very least not breaking any existing images.

---

Resolves #101 