### PR TITLE
Resolve incorrect "Repo" URLs being provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "markdown-it-highlightjs": "^4.0.1",
         "markdown-it-task-checkbox": "^1.0.6",
         "minify": "^9.2.0",
+        "parse-github-url": "^1.0.2",
         "superagent": "^8.0.1",
         "tailwindcss": "^3.2.4"
       },
@@ -4715,6 +4716,17 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "bin": {
+        "parse-github-url": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parse-json": {
@@ -9707,6 +9719,11 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
     },
     "parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "markdown-it-highlightjs": "^4.0.1",
     "markdown-it-task-checkbox": "^1.0.6",
     "minify": "^9.2.0",
+    "parse-github-url": "^1.0.2",
     "superagent": "^8.0.1",
     "tailwindcss": "^3.2.4"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 
 const MarkdownIt = require("markdown-it");
 const url = require('url');
+const ghurl = require("parse-github-url");
 let md = new MarkdownIt({
   html: true
 }).use(require("markdown-it-highlightjs"), {
@@ -253,21 +254,34 @@ function findRepoField(obj) {
                 (typeof obj.metadata.repository === "object" ? obj.metadata.repository.url : "" ));
   /**
     * For Information: ./docs/repository-urls.md
+    * Now we are using `https://github.com/jonschlinkert/parse-github-url`
+    * So there's no need to manually maintain this full code, but instead of complete deletion
+    * it will be mothballed by being commented out until a later time.
   */
 
-  if (reg.repoLink.standard.test(repo)) {
-    // Standard repo definition, it's a valid link. Return
-    return repo;
-  } else if (reg.repoLink.protocol.test(repo)) {
-    // Git Protocol Defined. Create normalized link.
-    let constru = repo.match(reg.repoLink.protocol);
-    return `https://github.com/${constru[1]}/${constru[2].replace(".git","")}`;
-  } else if (reg.repoLink.githubAssumedShorthand.test(repo)) {
-    return `https://github.com/${repo.match(reg.repoLink.githubAssumedShorthand)[0]}`;
-  } else if (reg.repoLink.githubShorthand.test(repo)) {
-    return `https://github.com/${repo.match(reg.repoLink.githubShorthand)[1]}`;
+
+  // if (reg.repoLink.standard.test(repo)) {
+  //   // Standard repo definition, it's a valid link. Return
+  //   return repo;
+  // } else if (reg.repoLink.protocol.test(repo)) {
+  //   // Git Protocol Defined. Create normalized link.
+  //   let constru = repo.match(reg.repoLink.protocol);
+  //   return `https://github.com/${constru[1]}/${constru[2].replace(".git","")}`;
+  // } else if (reg.repoLink.githubAssumedShorthand.test(repo)) {
+  //   return `https://github.com/${repo.match(reg.repoLink.githubAssumedShorthand)[0]}`;
+  // } else if (reg.repoLink.githubShorthand.test(repo)) {
+  //   return `https://github.com/${repo.match(reg.repoLink.githubShorthand)[1]}`;
+  // } else {
+  //   // We couldn't determine what to do here. Just return.
+  //   return repo;
+  // }
+
+  let repoObj = ghurl(repo);
+
+  if (repoObj.hasOwnProperty("repo")) {
+    return `https://github.com/${repoObj.repo}`;
   } else {
-    // We couldn't determine what to do here. Just return.
+    // Unable to parse URL, return as is
     return repo;
   }
 


### PR DESCRIPTION
While a [significant effort](https://github.com/pulsar-edit/package-frontend/blob/main/docs/repository-urls.md) was made to clean and properly parse GitHub repo URLs, seems some issues still got through the cracks.

So I've gone ahead and began using the wonderful dependency of [`parse-github-url`](https://github.com/jonschlinkert/parse-github-url) to do this job for us, and creating a link based off the value returned from there.

---

Resolves #84 