### PR TITLE
Better error reporting

### DIFF
--- a/ejs-views/pages/404.ejs
+++ b/ejs-views/pages/404.ejs
@@ -1,1 +1,0 @@
-<p>This Page is a 404! Sorry!</p>

--- a/ejs-views/pages/505.ejs
+++ b/ejs-views/pages/505.ejs
@@ -1,1 +1,0 @@
-<p>This Page encountered an Error! Sorry!</p>

--- a/ejs-views/pages/error.ejs
+++ b/ejs-views/pages/error.ejs
@@ -5,6 +5,11 @@
     <span class="text-3xl text-primary">This Page encountered an Error!</span>
   </div>
   <div id="readme" class="mt-12 prose max-w-none">
+    <h1>
+      If you think you're seeing this page in error. Please report an issue on
+      <a href="https://github.com/pulsar-edit/package-frontend">GitHub</a> or
+      <a href="https://discord.gg/7aEbB9dGRT">Discord</a>.
+    </h1>
     <pre>
       <code class="hljs language-json">
         <%-error%>

--- a/ejs-views/pages/error.ejs
+++ b/ejs-views/pages/error.ejs
@@ -1,0 +1,16 @@
+<%- include('../partials/header', { page }); %>
+
+<article>
+  <div class="w-full border border-secondary rounded p-3">
+    <span class="text-3xl text-primary">This Page encountered an Error!</span>
+  </div>
+  <div id="readme" class="mt-12 prose max-w-none">
+    <pre>
+      <code class="hljs language-json">
+        <%-error%>
+      </code>
+    </pre>
+  </div>
+</article>
+
+<%- include('../partials/footer'); %>

--- a/ejs-views/pages/error.ejs
+++ b/ejs-views/pages/error.ejs
@@ -7,7 +7,7 @@
   <div id="readme" class="mt-12 prose max-w-none">
     <h1>
       If you think you're seeing this page in error. Please report an issue on
-      <a href="https://github.com/pulsar-edit/package-frontend">GitHub</a> or
+      <a href="https://github.com/pulsar-edit/package-frontend/issues">GitHub</a> or
       <a href="https://discord.gg/7aEbB9dGRT">Discord</a>.
     </h1>
     <pre>

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -27,7 +27,18 @@ async function fullListingPage(req, res, timecop) {
       og_image_type: "image/svg+xml"
     }});
   } catch(err) {
-    utils.displayError(req, res, err);
+    utils.displayError(req, res, {
+      error: utils.modifyErrorText(err),
+      dev: DEV,
+      timecop: false,
+      page: {
+        name: "PPR Error Page",
+        og_url: "https://web.pulsar-edit.dev/packages",
+        og_description: "THe Pulsar Package Repository",
+        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image_type: "image/svg+xml"
+      }
+    });
   }
 }
 
@@ -54,7 +65,18 @@ async function singlePackageListing(req, res, timecop) {
       og_image_height: 600,
     }});
   } catch(err) {
-    utils.displayError(req, res, err);
+    utils.displayError(req, res, {
+      error: utils.modifyErrorText(err),
+      dev: DEV,
+      timecop: false,
+      page: {
+        name: "PPR Error Page",
+        og_url: "https://web.pulsar-edit.dev/packages",
+        og_description: "THe Pulsar Package Repository",
+        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image_type: "image/svg+xml"
+      }
+    });
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,17 +21,27 @@ const reg = require("./reg.js");
 
 // Collection of utility functions for the frontend
 
-async function displayError(req, res, errStatus) {
-  switch(errStatus) {
-    case 404:
-      res.status(404).render('404');
-      break;
-    case 505:
-      res.status(505).render('505');
-      break;
-    default:
-      res.status(505).render('505');
-      break;
+async function displayError(req, res, details) {
+  console.error(details);
+  res.status(500).render('error', details);
+}
+
+function modifyErrorText(err) {
+  // This function takes an error object, or error message string, and attempts
+  // to find the optimal formatting of the message to display to users.
+
+  if (typeof err === "object") {
+    if (typeof err.status === "number") {
+      // This is likely an error thrown from `superagent`
+      let text = `'${err.status}' Received from '${err?.response?.req?.host}${err?.response?.req?.path}'\n\t\t ${err.toString()}`;
+      return text;
+    } else {
+      // TODO Additional possibilities added here
+      return err;
+    }
+  } else {
+    // We likely already have an error message string
+    return err;
   }
 }
 
@@ -463,4 +473,5 @@ module.exports = {
   prepareForDetail,
   getPagination,
   Timecop,
+  modifyErrorText
 };


### PR DESCRIPTION
This PR adds much better error reporting to the package frontend.

Previously any and all errors are swallowed on the frontend, showing generic, ugly, unstyled error pages. Even worse, not logging the nature of the error.

This PR fixes all of these issues, instead by creating an error page that maintains the style of the site, while also showing the error to the user, in such a way that they may be able to find the issue at hand, or if need be, report a detailed error message to us in the event they see this screen.

Additionally, this PR logs the errors as well.

---

This PR focuses on adding this behavior to the package list pages, as well as the individual package pages. As these are we are seeing the vast majority of our errors occur.

This PR is also the first step needed in determining what is going wrong with our recurrent rogue instances of the PPR frontend, when an instance goes rogue and causes the chance for failure for users. Since as of now, we are completely in the dark in what goes wrong, having proper logging, and even better being much more transparent about what's gone wrong, will hopefully be the first and final step needed to determine why this happens, and how we can fix it.