### PR TITLE
Fix site-wide 404 & Pass along HTTP status info to error handler

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -69,7 +69,7 @@ async function singlePackageListing(req, res, timecop) {
     // we initialize as boolean to no-op in the case we don't find a proper status
 
     const validStatusIs = (val, key) => {
-      if (val?.response?.[key] && typeof val.response[key] === "boolean" && val.response[key]) {
+      if (typeof val?.response?.[key] === "boolean" && val.response[key]) {
         return true;
       } else {
         return false;

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -68,7 +68,7 @@ async function singlePackageListing(req, res, timecop) {
     let status_to_display = false; // Since the status is ignored if not a number,
     // we initialize as boolean to no-op in the case we don't find a proper status
 
-    const validStatus = (val, key) => {
+    const validStatusIs = (val, key) => {
       if (val?.response?.[key] && typeof val.response[key] === "boolean" && val.response[key]) {
         return true;
       } else {
@@ -76,13 +76,13 @@ async function singlePackageListing(req, res, timecop) {
       }
     };
 
-    if (validStatus(err, "notFound")) {
+    if (validStatusIs(err, "notFound")) {
       status_to_display = 404;
-    } else if (validStatus(err, "unauthorized")) {
+    } else if (validStatusIs(err, "unauthorized")) {
       status_to_display = 401;
-    } else if (validStatus(err, "forbidden")) {
+    } else if (validStatusIs(err, "forbidden")) {
       status_to_display = 403;
-    } else if (validStatus(err, "badRequest")) {
+    } else if (validStatusIs(err, "badRequest")) {
       status_to_display = 400;
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -72,18 +72,18 @@ app.get("/logout", async (req, res) => {
 app.use(async (req, res) => {
   // 404 here, keep at last position
   await utils.displayError(req, res, {
-      error: `The page '${req.url}' cannot be found.`,
-      dev: DEV,
-      timecop: false,
-      page: {
-        name: "PPR Error Page",
-        og_url: "https://web.pulsar-edit.dev/packages",
-        og_description: "The Pulsar Package Repository",
-        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
-        og_image_type: "image/svg+xml"
-      },
-      status_to_display: 404
-    });
+    error: `The page '${req.url}' cannot be found.`,
+    dev: DEV,
+    timecop: false,
+    page: {
+      name: "PPR Error Page",
+      og_url: "https://web.pulsar-edit.dev/packages",
+      og_description: "The Pulsar Package Repository",
+      og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+      og_image_type: "image/svg+xml"
+    },
+    status_to_display: 404
+  });
 });
 
 module.exports = app;

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@ const path = require("path");
 const handlers = require("./handlers.js");
 const utils = require("./utils.js");
 
+const DEV = process.env.PULSAR_STATUS === "dev" ? true : false;
+
 app.set("views", "./ejs-views/pages");
 app.set("view engine", "ejs");
 
@@ -69,7 +71,19 @@ app.get("/logout", async (req, res) => {
 
 app.use(async (req, res) => {
   // 404 here, keep at last position
-  await utils.displayError(req, res, 404);
+  await utils.displayError(req, res, {
+      error: `The page '${req.url}' cannot be found.`,
+      dev: DEV,
+      timecop: false,
+      page: {
+        name: "PPR Error Page",
+        og_url: "https://web.pulsar-edit.dev/packages",
+        og_description: "The Pulsar Package Repository",
+        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image_type: "image/svg+xml"
+      },
+      status_to_display: 404
+    });
 });
 
 module.exports = app;

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ const reg = require("./reg.js");
 
 async function displayError(req, res, details) {
   console.error(details);
-  if (details?.status_to_display && typeof details.status_to_display === "number") {
+  if (typeof details?.status_to_display === "number") {
     res.status(details.status_to_display).render("error", details);
   } else {
     res.status(500).render("error", details);

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,11 @@ const reg = require("./reg.js");
 
 async function displayError(req, res, details) {
   console.error(details);
-  res.status(500).render('error', details);
+  if (details?.status_to_display && typeof details.status_to_display === "number") {
+    res.status(details.status_to_display).render("error", details);
+  } else {
+    res.status(500).render("error", details);
+  }
 }
 
 function modifyErrorText(err) {


### PR DESCRIPTION
With the brand new logging we have setup, I was able to find a bug occurring in prod. While the error handler expected an object, it was only being given a `404` status code number during the site wide 404 error. Which would cause it to crash.

This PR fixes this, ensuring that site wide 404's are caught properly by the generic error handler. 
Additionally, I've gone ahead and added some logic that lets other errors, such as those when displaying an individual package page, can bubble up the HTTP status code they received to the error handler, providing the HTTP error code the user will actually receive. Which can help make the logs easier to inspect, and keeps things much more accurate