### PR TITLE
Whoops

### DIFF
--- a/ejs-views/partials/search_description.ejs
+++ b/ejs-views/partials/search_description.ejs
@@ -1,6 +1,6 @@
 <%
   const TYPE_VALUES = new Set(['provided', 'consumed']);
-  let serviceSpecified = locals.serviceType && TYPE_VALUES.has(locals.serviceName);
+  let serviceSpecified = locals.serviceType && TYPE_VALUES.has(locals.serviceType);
   let serviceTypeVerb = locals.serviceType === 'provided' ? 'provide' : 'consume';
 %>
 


### PR DESCRIPTION
Fix a thing I snuck into the last PR. I didn't want it showing the search description text unless `serviceType` was one of the expected values.