### PR TITLE
Fix naive iteration of service listing

### DIFF
--- a/ejs-views/partials/service_listing.ejs
+++ b/ejs-views/partials/service_listing.ejs
@@ -1,21 +1,30 @@
-<% if (pack.consumedServices || pack.providedServices) { %>
+<% if (pack?.consumedServices || pack?.providedServices) { %>
 <%
 
   function urlForPackageSearch (serviceName, serviceType) {
     return `/packages?serviceType=${serviceType}&service=${serviceName}`;
   }
 
-  function aggregateServices(services) {
+  function aggregateServices(services = {}) {
     let aggregated = new Map();
+    if (!services || typeof services !== "object") return aggregated;
     for (let name in services) {
-      let versions = Object.keys(services[name].versions);
+      let service = services[name];
+      if (!service.versions || typeof service.versions !== "object") {
+        // Malformed object. Pulsar won't understand it, so we shouldn't treat
+        // it as valid.
+        //
+        // (Example: https://github.com/ayame113/atom-ide-deno/blob/main/package.json#L66-L72)
+        continue;
+      }
+      let versions = Object.keys(service.versions);
       aggregated.set(name, versions);
     }
     return aggregated;
   }
 
 
-  let { consumedServices, providedServices } = pack;
+  let { consumedServices = {}, providedServices = {} } = pack;
   let consumed = aggregateServices(consumedServices);
   let provided = aggregateServices(providedServices);
 %>


### PR DESCRIPTION
My original stab at this in #125 wasn't paranoid enough. After all, we're reading from a random `package.json` file, and there's no guarantee that the format of that file will be what we expect.

In this case, the `atom-ide-deno` package detail page was 500ing [because of this apparent nesting error](https://github.com/ayame113/atom-ide-deno/blob/main/package.json#L66-L72) in the JSON.

The fix is to do poor-man's validation of the JSON as we're consuming it, bailing if anything isn't what we expect.

### Verification

https://web.pulsar-edit.dev/packages/atom-ide-deno will fail on `main`; http://localhost:8091/packages/atom-ide-deno will succeed when run locally on this PR branch.