### PR TITLE
Ensure `pack` is available within `md.renderer.rules.image`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -42,6 +42,9 @@ function addCustomMarkdownHandling () {
   let defaultImageRender = md.renderer.rules.image;
 
   md.renderer.rules.image = function(tokens, idx, options, env, self) {
+    // HACK: Get the `pack` object from an outer scope so that we don't have
+    // to redefine this handler on every request.
+    let pack = currentPackage;
     let token = tokens[idx];
     let aIndex = token.attrIndex('src');
 


### PR DESCRIPTION
Followup to #127 
We need to ensure within the `md.renderer.rules.image` handling that `pack` is set as well, whereas it's currently just available within `md.core.ruler.after()`