### PR TITLE
[download-microservice] Improve Error Handling

### DIFF
--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -110,6 +110,17 @@ async function findLink(os, type) {
 
     let releases = await doRequest();
 
+    if (!Array.isArray(releases)) {
+      console.error("GitHub Returned invalid data on release request!");
+      console.error(releases);
+
+      return {
+        ok: false,
+        code: 500,
+        msg: "Request to GitHub for releases failed."
+      };
+    }
+
     // Now these releases should be sorted already, if we find they aren't we might
     // have to add semver as a dep on this microservice, which is no fun since this
     // microservice has 0 deps currently. For now lets assume it's a sorted array

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -38,6 +38,10 @@ function query_os(req) {
   let raw = req; // The URL string containing any number of query params.
   let prov = undefined;
 
+  if (typeof raw !== "string") {
+    return false;
+  }
+
   let full = raw.split("&");
 
   for (const param of full) {


### PR DESCRIPTION
This PR addresses the two issues we are seeing in the `download` microservice:

* The `releases` object not being iterable. This object is defined by what GitHub returns so we have minimal control over it. While there is an error check for this step in the form of a `try...catch` handler, we can add a check here to validate we are working with an array, and if not return that we got improper data from GitHub. As well as log what we received, so that we can investigate the issue better.
* When we work with the parameters provided by users, we previously would call just `.split()` on the value, not checking if we had received a string. When this occurs it was uncaught, causing the entire microservice to crash. Now we can validate we have a string or if not bail early. 