### PR TITLE
[download-microservice] Auth All GitHub Requests

### DIFF
--- a/microservices/download/service.yaml
+++ b/microservices/download/service.yaml
@@ -5,5 +5,12 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: download-frontend@pulsar-357404.iam.gserviceaccount.com
       containers:
         - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/download:2.0.1"
+          env:
+          - name: GH_TOKEN_DOWNLOAD_MICROSERVICE
+            valueFrom:
+              secretKeyRef:
+                key: latest
+                name: GH_TOKEN_DOWNLOAD_MICROSERVICE

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -1,4 +1,18 @@
 const https = require("node:https");
+let TOKEN = process.env.GH_TOKEN_DOWNLOAD_MICROSERVICE;
+
+// Environment Variables Check
+
+if (typeof TOKEN === "undefined") {
+  if (process.env.PULSAR_STATUS === "dev") {
+    // We are in dev mode, assign dev values
+    TOKEN = "123456";
+  } else {
+    // We are not in dev mode. Our secrets are gone and the application will fail to work
+    console.log("Missing Required Environment Variables! Something has gone wrong!");
+    process.exit(1);
+  }
+}
 
 function doRequest() {
 
@@ -8,7 +22,8 @@ function doRequest() {
     method: 'GET',
     headers: {
       'Accept': 'application/vnd.github+json',
-      'User-Agent': 'pulsar-edit/package-frontend/microservices/download'
+      'User-Agent': 'pulsar-edit/package-frontend/microservices/download',
+      'Authorization': `Bearer ${TOKEN}`
     }
   };
 


### PR DESCRIPTION
Up until now we have had no authentication on the `download` microservice.

With not enough consistent traffic to justify the setup and managing of keys.

But just recently we have been seeing consistent failures when users attempt to download rolling release versions and after #130 we can view the data returned from GitHub to discover we are actually running out of generic rate limit requests allotted. Which means we are having more than 60 requests for rolling releases per hour, which is insane in it's own right.

This PR adds the capabilities of the `download` microservice to get credentials to authenticate to GitHub to ensure we don't run out of these requests.