### PR TITLE
[download-microservice] Refactor: Clarify Execution, make bin finding clearer

### DIFF
--- a/microservices/download/bins.js
+++ b/microservices/download/bins.js
@@ -1,0 +1,88 @@
+// A module that defines the way we locate a specific binary file amid all possible
+// Pulsar Rolling Release binaries.
+// In order to do this the following keys are available:
+//  - startsWith: Checks if the version string startsWith the value
+//  - endsWith: Checks if the version string endsWith the value
+//  - endsWithNot: Checks if the version string does not end with the value
+
+module.exports = {
+  windows: {
+    windows_setup: {
+      startsWith: "Pulsar.Setup",
+      endsWith: ".exe"
+    },
+    windows_portable: {
+      endsWith: "-win.zip"
+    },
+    windows_blockmap: {
+      startsWith: "Pulsar.Setup",
+      endsWith: ".exe.blockmap"
+    }
+  },
+
+  silicon_mac: {
+    mac_zip: {
+      endsWith: "-arm64-mac.zip"
+    },
+    mac_zip_blockmap: {
+      endsWith: "-arm64-mac.zip.blockmap"
+    },
+    mac_dmg: {
+      endsWith: "-arm64.dmg"
+    },
+    mac_dmg_blockmap: {
+      endsWith: "-arm64.dmg.blockmap"
+    }
+  },
+
+  intel_mac: {
+    mac_zip: {
+      endsWith: "-mac.zip",
+      endsWithNot: "-arm64-mac.zip"
+    },
+    mac_zip_blockmap: {
+      endsWith: "-mac.zip.blockmap",
+      endsWithNot: "-arm64-mac.zip.blockmap"
+    },
+    mac_dmg: {
+      endsWith: ".dmg",
+      endsWithNot: "-arm64.dmg"
+    },
+    mac_dmg_blockmap: {
+      endsWith: ".dmg.blockmap",
+      endsWithNot: "-arm64.dmg.blockmap"
+    }
+  },
+
+  arm_linux: {
+    linux_appimage: {
+      endsWith: "-arm64.AppImage"
+    },
+    linux_tar: {
+      endsWith: "-arm64.tar.gz"
+    },
+    linux_rpm: {
+      endsWith: ".aarch64.rpm"
+    },
+    linux_deb: {
+      endsWith: "_arm64.deb"
+    }
+  },
+
+  linux: {
+    linux_appimage: {
+      endsWith: ".AppImage",
+      endsWithNot: "-arm64.AppImage"
+    },
+    linux_tar: {
+      endsWith: ".tar.gz",
+      endsWithNot: "-arm64.tar.gz"
+    },
+    linux_rpm: {
+      endsWith: ".x86_64.rpm"
+    },
+    linux_deb: {
+      endsWith: "_amd64.deb"
+    }
+  }
+};

--- a/microservices/download/index.js
+++ b/microservices/download/index.js
@@ -3,14 +3,17 @@ const utils = require("./utils.js");
 const port = parseInt(process.env.PORT) || 8080;
 
 const server = http.createServer(async (req, res) => {
-  // Since req.url is our URL pluse query params, lets split them first.
-  const path = req.url.split("?");
+  // Since req.url is our URL plus query params, lets split them first.
+  const url = req.url.split("?");
+  const path = url[0];
+  const queryParams = url[1];
+
   // Set our Request Route
-  if (path[0] === "/" && req.method === "GET") {
+  if (path === "/" && req.method === "GET") {
 
     let params = {
-      os: utils.query_os(path[1]),
-      type: utils.query_type(path[1])
+      os: utils.query_os(queryParams),
+      type: utils.query_type(queryParams)
     };
 
     if (!params.os || !params.type) {

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -1,6 +1,20 @@
 const https = require("node:https");
 const bins = require("./bins.js");
 let TOKEN = process.env.GH_TOKEN_DOWNLOAD_MICROSERVICE;
+const VALID_OS = [ "linux", "arm_linux", "silicon_mac", "intel_mac", "windows" ];
+const VALID_TYPE = [
+  "linux_appimage",
+  "linux_tar",
+  "linux_rpm",
+  "linux_deb",
+  "windows_setup",
+  "windows_portable",
+  "windows_blockmap",
+  "mac_zip",
+  "mac_zip_blockmap",
+  "mac_dmg",
+  "mac_dmg_blockmap"
+];
 
 // Environment Variables Check
 
@@ -60,14 +74,13 @@ function query_os(queryString) {
   }
 
   const allParams = queryString.split("&");
-  const valid = [ "linux", "arm_linux", "silicon_mac", "intel_mac", "windows" ];
 
   for (const param of allParams) {
     if (param.startsWith("os=")) {
       // Returning a result based on the first "os=" param we encounter.
       // Users should not provide the same param twice, that would be invalid.
       const prov = param.split("=")[1];
-      return valid.includes(prov) ? prov : false;
+      return VALID_OS.includes(prov) ? prov : false;
     }
   }
 
@@ -81,26 +94,13 @@ function query_type(queryString) {
   }
 
   const allParams = queryString.split("&");
-  const valid = [
-    "linux_appimage",
-    "linux_tar",
-    "linux_rpm",
-    "linux_deb",
-    "windows_setup",
-    "windows_portable",
-    "windows_blockmap",
-    "mac_zip",
-    "mac_zip_blockmap",
-    "mac_dmg",
-    "mac_dmg_blockmap"
-  ];
 
   for (const param of allParams) {
     if (param.startsWith("type=")) {
       // Returning a result based on the first "type=" param we encounter.
       // Users should not provide the same param twice, that would be invalid.
       const prov = param.split("=")[1];
-      return valid.includes(prov) ? prov : false;
+      return VALID_TYPE.includes(prov) ? prov : false;
     }
   }
 

--- a/microservices/download/utils.js
+++ b/microservices/download/utils.js
@@ -93,6 +93,10 @@ function query_type(param) {
   let raw = param;
   let prov = undefined;
 
+  if (typeof raw !== "string") {
+    return false;
+  }
+
   let full = raw.split("&");
 
   for (const param of full) {


### PR DESCRIPTION
This PR first addresses some great points @DeeDeeG brought up about code clarity, and aims to make things much more clear in behavior.

Secondly, since a refactor was already taking place, this PR removes likely the biggest portion of code. That is finding the bins. Previously this was a big long `if...else` which has no been replaced by a simple object, that allows easy lookup and definition of how to find each bin.

The `./bin.js` file exports an object where the top level key is the OS for each supported platform, which itself then has a top level key to each `type` of supported installation on said platform. From there the following keys are supported to execute a check against the binary asset name:

* `startsWith`: Executes `string.startsWith(value)`
* `endsWith`: Executes `string.endsWith(value)`
* `endsWithNot`: Executes `!string.endsWith(value)`

This way instead of repetitive code, with the definitions of how we find the binaries obscured within it, we instead have a single function decode this object into code with the clarity of the definitions being much more important.