### PR TITLE
Stop Handling Bundled Packages on the Frontend

### DIFF
--- a/ejs-views/partials/package_listing.ejs
+++ b/ejs-views/partials/package_listing.ejs
@@ -130,7 +130,7 @@
       </div>
     </div>
     <% } %>
-    <% if (!pack.isBundled) { %>
+    <% if (!pack.is_bundled) { %>
       <a href="<%=pack.install%>" class="hidden sm:flex items-center justify-center mt-3 md:mt-0">
         <button class="w-full md:w-auto">
           <i class="fas fa-download mr-2"></i>

--- a/src/utils.js
+++ b/src/utils.js
@@ -197,22 +197,13 @@ function prepareForListing(obj) {
         pack.downloads = obj[i].downloads ? obj[i].downloads : 0;
         pack.stars = obj[i].stargazers_count ? obj[i].stargazers_count : 0;
         pack.install = `atom://settings-view/show-package?package=${pack.name}`;
+        pack.is_bundled = obj[i].is_bundled ?? false;
 
         // Cleanup the data
         pack.stars = Number(pack.stars).toLocaleString();
         pack.downloads = Number(pack.downloads).toLocaleString();
 
         pack.badges = obj[i].badges ?? [];
-
-        // Apply any bundled package logic
-        if (isBundledPackage(pack.name)) {
-          pack.isBundled = true;
-          pack.badges.push({
-            type: "info",
-            title: "Bundled",
-            link: "https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/badge_spec.md#bundled"
-          });
-        }
 
         packList.push(pack);
       } catch(err) {
@@ -255,6 +246,7 @@ function prepareForDetail(obj) {
     pack.repoLink = findRepoField(obj);
     pack.bugLink = obj.metadata.bugs ? obj.metadata.bugs.url : "";
     pack.install = `atom://settings-view/show-package?package=${pack.name}`;
+    pack.is_bundled = obj.is_bundled ?? false;
 
     pack.providedServices = obj.metadata.providedServices ?? null;
     pack.consumedServices = obj.metadata.consumedServices ?? null;
@@ -286,16 +278,6 @@ function prepareForDetail(obj) {
     };
 
     pack.badges = obj.badges ?? [];
-
-    // Apply any bundled package logic
-    if (isBundledPackage(pack.name)) {
-      pack.isBundled = true;
-      pack.badges.push({
-        type: "info",
-        title: "Bundled",
-        link: "https://github.com/pulsar-edit/package-backend/blob/main/docs/reference/badge_spec.md#bundled"
-      });
-    }
 
     resolve(pack);
   });
@@ -445,40 +427,6 @@ function getPagination(req, api) {
       next: page < pages ? getRouteUrl(page + 1) : null,
       last: page < pages ? getRouteUrl(pages) : null,
     }
-  }
-}
-
-function isBundledPackage(name) {
-  // Takes the name of a package and returns true if that package is bundled
-  // within the Pulsar editor
-  const bundledPackages = [
-    "about", "archive-view", "atom-dark-syntax", "atom-dark-ui", "atom-light-syntax",
-    "atom-light-ui", "autocomplete-atom-api", "autocomplete-css", "autocomplete-html",
-    "autocomplete-plus", "autocomplete-snippets", "autoflow", "autosave", "background-tips",
-    "base16-tomorrow-dark-theme", "base16-tomorrow-light-theme", "bookmarks",
-    "bracket-matcher", "command-palette", "dalek", "deprecation-cop", "dev-live-reload",
-    "encoding-selector", "exception-reporting", "find-and-replace", "fuzzy-finder",
-    "git-diff", "go-to-line", "grammar-selector", "image-view", "incompatible-packages",
-    "keybinding-resolver", "language-c", "language-clojure", "language-coffee-script",
-    "language-csharp", "language-css", "language-gfm", "language-git", "language-go",
-    "language-html", "language-hyperlink", "language-java", "language-javascript",
-    "language-json", "language-less", "language-make", "language-mustache",
-    "language-objective-c", "language-perl", "language-php", "language-property-list",
-    "language-python", "language-ruby-on-rails", "language-ruby", "language-rust-bundled",
-    "language-sass", "language-shellscript", "language-source", "language-sql",
-    "language-text", "language-todo", "language-toml", "language-typescript",
-    "language-xml", "language-yaml", "line-ending-selector", "link", "markdown-preview",
-    "notifications", "one-dark-syntax", "one-dark-ui", "one-light-syntax", "one-light-ui",
-    "open-on-github", "package-generator", "settings-view", "solarized-dark-syntax",
-    "solarized-light-syntax", "status-bar", "styleguide", "tabs", "timecop", "tree-view",
-    "update-package-dependencies", "welcome", "whitespace", "wrap-guide",
-    "snippets", "symbols-view", "github", "spell-check"
-  ];
-
-  if (bundledPackages.includes(name)) {
-    return true;
-  } else {
-    return false;
   }
 }
 


### PR DESCRIPTION
This PR removes any special handling of Bundled packages from the frontend.

The handling of these packages is being moved to the backend, to ensure data accuracy for all clients.

This repo will still rely on the `is_bundled` property that will be available on bundled packages only.