### PR TITLE
Redirect all `web` traffic to `packages`

### DIFF
--- a/.github/workflows/frontend_test.yml
+++ b/.github/workflows/frontend_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 22.x]
 
     steps:
     - name: Checkout the latest code

--- a/app.example.yaml
+++ b/app.example.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 service: package-browser
 
 env_variables:

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,10 @@ app.set("views", "./ejs-views/pages");
 app.set("view engine", "ejs");
 
 app.use((req, res, next) => {
+  // Setup redirect of all `web` requests to `packages`
+  if (req.subdomains[0] === "web") {
+    res.status(301).redirect(`https://packages.pulsar-edit.dev${req.originalUrl}`);
+  }
   req.start = Date.now();
   next();
 });


### PR DESCRIPTION
With us launching the new subdomain for packages, and those changes being live we now just need to handle redirection for all old requests.

This PR also bumps the version of NodeJS we are using since v18 is no longer supported on App Engine