### PR TITLE
Update Subdomain links in Code

### DIFF
--- a/ejs-views/partials/header.ejs
+++ b/ejs-views/partials/header.ejs
@@ -22,8 +22,8 @@
     <meta name="description" content="<%=page.og_description%>">
     <meta charset="UTF-8">
     <meta name="application-name" content="ExpressJS">
-    <link rel="alternate" href="https://web.pulsar-edit.dev/" hreflang="x-default">
-    <link rel="alternate" href="https://web.pulsar-edit.dev/" hreflang="en">
+    <link rel="alternate" href="https://packages.pulsar-edit.dev/" hreflang="x-default">
+    <link rel="alternate" href="https://packages.pulsar-edit.dev/" hreflang="en">
     <link rel="shortcut icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="apple-touch-icon" type="image/svg+xml" href="/favicon.svg">
@@ -50,12 +50,12 @@
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://web.pulsar-edit.dev/",
+        "url": "https://packages.pulsar-edit.dev/",
         "potentialAction": {
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://web.pulsar-edit.dev/packages/search?q={search_term_string}"
+            "urlTemplate": "https://packages.pulsar-edit.dev/packages/search?q={search_term_string}"
           },
           "query-input": "required name=search_term_string"
         }
@@ -64,7 +64,7 @@
         "@context": "https://schema.org",
         "@type": "Organization",
         "url": "https://pulsar-edit.dev/",
-        "logo": "https://web.pulsar-edit.dev/public/pulsar_name.svg"
+        "logo": "https://packages.pulsar-edit.dev/public/pulsar_name.svg"
       },
       {
         "@context": "https://schema.org",
@@ -98,9 +98,9 @@
       </a>
       <nav class="fixed flex-col p-24 shadow-right md:static md:p-0 md:flex-row md:shadow-none md:h-auto flex z-10 h-screen top-0 -left-96 bg-accent gap-6 transition-all md:w-full">
         <i onclick="toggleNavBtn()" class="md:!hidden fas fa-times absolute top-5 right-5 text-white text-2xl cursor-pointer"></i>
-        <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/') { %> text-primary <% } %>" href="/">Featured</a>
-        <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/packages') { %> text-primary <% } %>" href="/packages">Packages</a>
-        <a class="<% if (page.og_url === 'https://web.pulsar-edit.dev/login') { %> text-primary <% } %>" href="/login">Sign In</a>
+        <a class="<% if (page.og_url === 'https://packages.pulsar-edit.dev/') { %> text-primary <% } %>" href="/">Featured</a>
+        <a class="<% if (page.og_url === 'https://packages.pulsar-edit.dev/packages') { %> text-primary <% } %>" href="/packages">Packages</a>
+        <a class="<% if (page.og_url === 'https://packages.pulsar-edit.dev/login') { %> text-primary <% } %>" href="/login">Sign In</a>
         <a href="https://pulsar-edit.dev" target="_blank">
           <i class="fas fa-arrow-up-right-from-square"></i>
           Website

--- a/public/site.js
+++ b/public/site.js
@@ -229,7 +229,7 @@ function userAccountLocal() {
   } else {
     // They haven't given us any query parameters, but don't have any local data either
     // Lets redirect to the sign in page.
-    window.location.href = "https://web.pulsar-edit.dev/login";
+    window.location.href = "https://pacakges.pulsar-edit.dev/login";
   }
 }
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -31,9 +31,9 @@ async function fullListingPage(req, res, timecop) {
         timecop: timecop.timetable,
         page: {
           name: "All Pulsar Packages",
-          og_url: "https://web.pulsar-edit.dev/packages",
+          og_url: "https://packages.pulsar-edit.dev/packages",
           og_description: "The Pulsar Package Repository",
-          og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+          og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
           og_image_type: "image/svg+xml"
         }
       }
@@ -45,9 +45,9 @@ async function fullListingPage(req, res, timecop) {
       timecop: false,
       page: {
         name: "PPR Error Page",
-        og_url: "https://web.pulsar-edit.dev/packages",
+        og_url: "https://packages.pulsar-edit.dev/packages",
         og_description: "The Pulsar Package Repository",
-        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
         og_image_type: "image/svg+xml"
       }
     });
@@ -73,7 +73,7 @@ async function singlePackageListing(req, res, timecop) {
       timecop: timecop.timetable,
       page: {
         name: obj.name,
-        og_url: `https://web.pulsar-edit.dev/packages/${obj.name}`,
+        og_url: `https://packages.pulsar-edit.dev/packages/${obj.name}`,
         og_description: obj.description,
         og_image: `https://image.pulsar-edit.dev/packages/${obj.name}?image_kind=${og_image_kind}&theme=${og_image_theme}`,
         og_image_type: "image/png",
@@ -109,9 +109,9 @@ async function singlePackageListing(req, res, timecop) {
       timecop: false,
       page: {
         name: "PPR Error Page",
-        og_url: "https://web.pulsar-edit.dev/packages",
+        og_url: "https://packages.pulsar-edit.dev/packages",
         og_description: "The Pulsar Package Repository",
-        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
         og_image_type: "image/svg+xml"
       },
       status_to_display: status_to_display
@@ -133,9 +133,9 @@ async function featuredPackageListing(req, res, timecop) {
       timecop: timecop.timetable,
       page: {
         name: "Featured Packages",
-        og_url: "https://web.pulsar-edit.dev/packages/featured",
+        og_url: "https://packages.pulsar-edit.dev/packages/featured",
         og_description: "The Pulsar Package Repository",
-        og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+        og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
         og_image_type: "image/svg+xml"
       }
     });
@@ -150,9 +150,9 @@ async function homePage(req, res, timecop) {
 
   let homePage = {
     name: "Pulsar Package Explorer",
-    og_url: "https://web.pulsar-edit.dev/",
+    og_url: "https://packages.pulsar-edit.dev/",
     og_description: "The Pulsar Package Repository",
-    og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+    og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
     og_image_type: "image/svg+xml"
   };
 
@@ -206,9 +206,9 @@ async function searchHandler(req, res, timecop) {
         timecop: timecop.timetable,
         page: {
           name: `Search ${req.query.q}`,
-          og_url: "https://web.pulsar-edit.dev/packages/search",
+          og_url: "https://packages.pulsar-edit.dev/packages/search",
           og_description: "The Pulsar Package Repository",
-          og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+          og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
           og_image_type: "image/svg+xml"
         }
       }
@@ -223,9 +223,9 @@ async function loginHandler(req, res, timecop) {
   // This is a very simple return with no api, so we will just render
   res.render("login", { dev: DEV, timecop: timecop.timetable, page: {
     name: "Pulsar Sign In/Up",
-    og_url: "https://web.pulsar-edit.dev/login",
+    og_url: "https://packages.pulsar-edit.dev/login",
     og_description: "The Pulsar User Sign In Page",
-    og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+    og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
     og_image_type: "image/svg+xml"
   }});
 }
@@ -234,9 +234,9 @@ async function logoutHandler(req, res, timecop) {
   // This is a very simple return with no api, so we will just render
   res.render("logout", { dev: DEV, timecop: timecop.timetable, page: {
     name: "Pulsar Logout",
-    og_url: "https://web.pulsar-edit.dev/logout",
+    og_url: "https://packages.pulsar-edit.dev/logout",
     og_description: "The Pulsar Log Out Page",
-    og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+    og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
     og_image_type: "image/svg+xml"
   }});
 }
@@ -247,9 +247,9 @@ async function userPageHandler(req, res, timecop) {
   // render a page and not do anything
   res.render("user_page", { dev: DEV, timecop: timecop.timetable, page: {
     name: "Pulsar User Account",
-    og_url: "https://web.pulsar-edit.dev/users",
+    og_url: "https://packages.pulsar-edit.dev/users",
     og_description: "The Pulsar User Account Page",
-    og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+    og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
     org_image_type: "image/svg+xml"
   }});
 }

--- a/src/main.js
+++ b/src/main.js
@@ -81,9 +81,9 @@ app.use(async (req, res) => {
     timecop: false,
     page: {
       name: "PPR Error Page",
-      og_url: "https://web.pulsar-edit.dev/packages",
+      og_url: "https://packages.pulsar-edit.dev/packages",
       og_description: "The Pulsar Package Repository",
-      og_image: "https://web.pulsar-edit.dev/public/pulsar_name.svg",
+      og_image: "https://packages.pulsar-edit.dev/public/pulsar_name.svg",
       og_image_type: "image/svg+xml"
     },
     status_to_display: 404

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ function addCustomMarkdownHandling () {
                 let link = attr[1];
                 if (reg.atomLinks.package.test(link)) {
                   // Fix any links that attempt to point to packages on `https://atom.io/packages/...`
-                  attr[1] = `https://web.pulsar-edit.dev/packages/${link.match(reg.atomLinks.package)[1]}`;
+                  attr[1] = `https://packages.pulsar-edit.dev/packages/${link.match(reg.atomLinks.package)[1]}`;
 
                 } else if (pack && reg.localLinks.currentDir.test(link)) {
                   // Since we are here let's check for any other links to
@@ -270,10 +270,10 @@ function prepareForDetail(obj) {
 
     // Add Sharing data to it for easy access to the package_listing
     pack.share = {
-      pageLink: `https://web.pulsar-edit.dev/packages/${pack.name}`,
+      pageLink: `https://packages.pulsar-edit.dev/packages/${pack.name}`,
       mdLink: {
-        default: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name})](https://web.pulsar-edit.dev/packages/${pack.name})`,
-        iconic: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=iconic)](https://web.pulsar-edit.dev/packages/${pack.name})`
+        default: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name})](https://packages.pulsar-edit.dev/packages/${pack.name})`,
+        iconic: `[![${pack.name}](https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=iconic)](https://packages.pulsar-edit.dev/packages/${pack.name})`
       }
     };
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -6,4 +6,4 @@ User-agent: AdsBot-Google-Mobile-Apps
 Allow: /
 User-agent: FriendlyCrawler
 Disallow: /
-Sitemap: https://web.pulsar-edit.dev/sitemap.xml
+Sitemap: https://packages.pulsar-edit.dev/sitemap.xml

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://web.pulsar-edit.dev/</loc>
+    <loc>https://packages.pulsar-edit.dev/</loc>
     <lastmod>2022-11-04</lastmod>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
With the new subdomain officially out, this PR updates quite a few locations where it appears in code.

To be clear all of these links will continue to work as we simply redirect users who hit `web` while retaining all paths and query parameters. But it's good practice to get all of this updated anyway