### PR TITLE
Create `search` microservice

### DIFF
--- a/microservices/search/.dockerignore
+++ b/microservices/search/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+node_modules/
+README.md

--- a/microservices/search/Dockerfile
+++ b/microservices/search/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+FROM node:18-slim
+
+# Below we use Dockerfile Labels w/ predefined annotation keys to properly link arbitrary
+# container images to the proper Pulsar Repo.
+LABEL org.opencontainers.artifact.description="Microservice to search Pulsar resources."
+LABEL org.opencontainers.image.source="https://github.com/pulsar-edit/package-frontend/tree/main/microservices/search"
+LABEL org.opencontainers.image.author="confused-Techie"
+LABEL org.opencontainers.image.license="MIT"
+LABEL org.opencontainers.image.description="Microservice to search Pulsar resources."
+LABEL org.opencontainers.image.documentation="https://github.com/pulsar-edit/package-frontend/blob/main/microservices/search/README.md"
+LABEL description="Microservice to search Pulsar resources."
+
+# Create and change to the app directory
+WORKDIR /usr/src/app
+
+# Copy application dependency manifests to the container image.
+COPY package*.json ./
+
+# Install production dependencies
+RUN npm install --only=production
+
+# Copy local code to the container image.
+COPY . ./
+
+# Run the web service on container startup
+CMD [ "npm", "start" ]

--- a/microservices/search/README.md
+++ b/microservices/search/README.md
@@ -1,0 +1,29 @@
+# Search
+
+This microservice allows search on Pulsar's static websites.
+
+While sites like the backend (and implicitly the frontend) have search capabilities
+built in, for our static sites, such as the docs or blog, they have no way to search their content.
+
+This microservice allows a somewhat novel way to accomplish that, without having to suck
+up a users resources by preforming the search client side.
+
+The search microservice responds to a `POST /reindex/:domain` request which will collect
+the `search-index.jsonl` document at the root of the subdomain and will build a search index from it.
+
+Which it then responds to `GET /search/:domain?q=` requests and preforms a search against that index.
+
+Search capabilities are provided via [lunr](https://lunrjs.com/) and as such support all of the features of that library, such as boosts, fuzzy matches, wildcards, etc (as [described](https://lunrjs.com/guides/searching.html)).
+
+## Users of Search
+
+For advanced search features please reference [lunr docs](https://lunrjs.com/guides/searching.html).
+
+## Integrators
+
+When integrating `search` into a new Pulsar subdomain, ensure:
+* To output a document `search-index.jsonl` at the root of the domain.
+* That the document has the fields: `url`, `title`, and `body`.
+* That the new domain is mapped in the `./index.js` file.
+
+Then the response of `GET /search/:domain?q=` will match the response described [here](https://lunrjs.com/guides/core_concepts.html#search-results).

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -1,3 +1,4 @@
+const path = require("node:path");
 const express = require("express");
 const Search = require("./search.js");
 
@@ -18,7 +19,7 @@ app.post("/reindex/:domain", async (req, res) => {
   if (!domain) {
     // We don't support whatever domain was provided
     res.status(400).append("Content-Type", "application/problem+json").json({
-      type: "https://search.pulsar-edit.dev/problems/unsupported-domain",
+      type: `${apiurl}/problems/unsupported-domain`,
       status: 400,
       title: "The Domain provided is not supported."
     });
@@ -33,10 +34,9 @@ app.post("/reindex/:domain", async (req, res) => {
 
     if (err.toString() === "The data stream is undefined!") {
       res.status(500).append("Content-Type", "application/problem+json").json({
-        type: "about:blank",
+        type: `${apiurl}/problems/unknown-data-stream`,
         status: 500,
-        title: "The data stream location couldn't be identified.",
-        detail: err.toString()
+        title: "The data stream location couldn't be identified."
       });
     } else {
       res.status(500).append("Content-Type", "application/problem+json").json({
@@ -65,7 +65,7 @@ app.get("/search/:domain", async (req, res) => {
   if (!domain) {
     // We don't support whatever domain was provided
     res.status(400).append("Content-Type", "application/problem+json").json({
-      type: "https://search.pulsar-edit.dev/problems/unsupported-domain",
+      type: `${apiurl}/problems/unsupported-domain`,
       status: 400,
       title: "The Domain provided is not supported."
     });
@@ -97,8 +97,11 @@ app.get("/search/:domain", async (req, res) => {
 });
 
 app.get("/problems/unsupported-domain", async (req, res) => {
-  const path = require("node:path");
   res.sendFile(path.join(__dirname, "resources/problems/unsupported-domain.html"));
+});
+
+app.get("/problems/unknown-data-stream", async (req, res) => {
+  res.sendFile(path.join(__dirname, "resources/problems/unknown-data-stream.html"));
 });
 
 app.use(async (req, res) => {

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -30,6 +30,7 @@ app.post("/reindex/:domain", async (req, res) => {
   try {
     await idx.reindex();
   } catch(err) {
+    console.error("An error occurred when attempting to reindex the domain!");
     console.error(err);
 
     if (err.toString() === "The data stream is undefined!") {
@@ -52,9 +53,6 @@ app.post("/reindex/:domain", async (req, res) => {
   INDEXES[domain] = idx;
 
   res.status(201).send();
-
-  // After we have returned our response to the user, save our new index
-  INDEXES[domain].save();
 });
 
 app.get("/search/:domain", async (req, res) => {
@@ -139,3 +137,15 @@ app.use((err, req, res, _next) => {
 app.listen(port, () => {
   console.log(`Search Microservice exposed on port: ${port}`);
 });
+
+process.on("SIGTERM", async () => {
+  await exterminate();
+});
+
+process.on("SIGINT", async () => {
+  await exterminate();
+});
+
+async function exterminate() {
+  app.close();
+}

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -10,11 +10,6 @@ const DOMAIN_MAP = {
 };
 const INDEXES = {}; // Instances of the search class w/ domain as the key
 
-app.get("/file", async (req, res) => {
-  const path = require("path");
-  res.sendFile(path.join(__dirname, "search-index.jsonl"));
-});
-
 app.post("/reindex/:domain", async (req, res) => {
   // Endpoint to trigger a re-index of content for a given sub-domain
   let domain = req.params.domain;
@@ -22,7 +17,11 @@ app.post("/reindex/:domain", async (req, res) => {
 
   if (!domain) {
     // We don't support whatever domain was provided
-    res.status(400).json({ err: "The Domain provided is not supported." });
+    res.status(400).append("Content-Type", "application/problem+json").json({
+      type: "https://search.pulsar-edit.dev/problems/unsupported-domain",
+      status: 400,
+      title: "The Domain provided is not supported."
+    });
     return;
   }
 
@@ -31,13 +30,28 @@ app.post("/reindex/:domain", async (req, res) => {
     await idx.reindex();
   } catch(err) {
     console.error(err);
-    res.status(500).json({ err: err.toString() });
+
+    if (err.toString() === "The data stream is undefined!") {
+      res.status(500).append("Content-Type", "application/problem+json").json({
+        type: "about:blank",
+        status: 500,
+        title: "The data stream location couldn't be identified.",
+        detail: err.toString()
+      });
+    } else {
+      res.status(500).append("Content-Type", "application/problem+json").json({
+        type: "about:blank",
+        status: 500,
+        title: "An unexpected problem occurred when attempting to reindex this domain.",
+        detail: err.toString()
+      });
+    }
     return;
   }
 
   INDEXES[domain] = idx;
 
-  res.status(201).json({ message: "Successfully reindexed" });
+  res.status(201).send();
 
   // After we have returned our response to the user, save our new index
   INDEXES[domain].save();
@@ -50,7 +64,11 @@ app.get("/search/:domain", async (req, res) => {
 
   if (!domain) {
     // We don't support whatever domain was provided
-    res.status(400).json({ err: "The Domain provided is not supported." });
+    res.status(400).append("Content-Type", "application/problem+json").json({
+      type: "https://search.pulsar-edit.dev/problems/unsupported-domain",
+      status: 400,
+      title: "The Domain provided is not supported."
+    });
     return;
   }
 
@@ -61,7 +79,12 @@ app.get("/search/:domain", async (req, res) => {
       await idx.load();
     } catch(err) {
       console.error(err);
-      res.status(500).json({ err: err.toString() });
+      res.status(500).append("Content-Type", "application/problem+json").json({
+        type: "about:blank",
+        status: 500,
+        title: "An error occurred when attempting to load the needed search index.",
+        detail: err.toString()
+      });
       return;
     }
 
@@ -75,13 +98,22 @@ app.get("/search/:domain", async (req, res) => {
 
 app.use(async (req, res) => {
   // 404 error
-  res.status(404).json({ message: "Not Found" });
+  res.status(404).append("Content-Type", "application/problem+json").json({
+    type: "about:blank",
+    status: 404,
+    title: "Not Found"
+  });
 });
 
 app.use((err, req, res, _next) => {
   // Global error handler, for internal logic & ExpressJS errors
   console.error(err);
-  res.status(500).json({ err: err.toString() });
+  res.status(500).append("Content-Type", "application/problem+json").json({
+    type: "about:blank",
+    status: 500,
+    title: "An error occurred when attempting to respond to your request.",
+    detail: err.toString()
+  });
 });
 
 app.listen(port, () => {

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -96,6 +96,11 @@ app.get("/search/:domain", async (req, res) => {
   res.status(200).json({ results: result });
 });
 
+app.get("/problems/unsupported-domain", async (req, res) => {
+  const path = require("node:path");
+  res.sendFile(path.join(__dirname, "resources/problems/unsupported-domain.html"));
+});
+
 app.use(async (req, res) => {
   // 404 error
   res.status(404).append("Content-Type", "application/problem+json").json({

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -1,0 +1,89 @@
+const express = require("express");
+const Search = require("./search.js");
+
+const app = express();
+const port = parseInt(process.env.PORT) || 8080;
+const apiurl = process.env.APIURL || "https://search.pulsar-edit.dev";
+const DOMAIN_MAP = {
+  "docs": "docs.pulsar-edit.dev",
+  "blog": "blog.pulsar-edit.dev"
+};
+const INDEXES = {}; // Instances of the search class w/ domain as the key
+
+app.get("/file", async (req, res) => {
+  const path = require("path");
+  res.sendFile(path.join(__dirname, "search-index.jsonl"));
+});
+
+app.post("/reindex/:domain", async (req, res) => {
+  // Endpoint to trigger a re-index of content for a given sub-domain
+  let domain = req.params.domain;
+  domain = DOMAIN_MAP[domain];
+
+  if (!domain) {
+    // We don't support whatever domain was provided
+    res.status(400).json({ err: "The Domain provided is not supported." });
+    return;
+  }
+
+  const idx = new Search(domain);
+  try {
+    await idx.reindex();
+  } catch(err) {
+    console.error(err);
+    res.status(500).json({ err: err.toString() });
+    return;
+  }
+
+  INDEXES[domain] = idx;
+
+  res.status(201).json({ message: "Successfully reindexed" });
+
+  // After we have returned our response to the user, save our new index
+  INDEXES[domain].save();
+});
+
+app.get("/search/:domain", async (req, res) => {
+  // Endpoint to preform a search of a given sub-domain
+  let domain = req.params.domain;
+  domain = DOMAIN_MAP[domain];
+
+  if (!domain) {
+    // We don't support whatever domain was provided
+    res.status(400).json({ err: "The Domain provided is not supported." });
+    return;
+  }
+
+  if (!INDEXES[domain]) {
+    // We don't have the search index for this domain loaded yet
+    const idx = new Search(domain);
+    try {
+      await idx.load();
+    } catch(err) {
+      console.error(err);
+      res.status(500).json({ err: err.toString() });
+      return;
+    }
+
+    INDEXES[domain] = idx;
+  }
+
+  const result = INDEXES[domain].search(req.query.q);
+
+  res.status(200).json({ results: result });
+});
+
+app.use(async (req, res) => {
+  // 404 error
+  res.status(404).json({ message: "Not Found" });
+});
+
+app.use((err, req, res, _next) => {
+  // Global error handler, for internal logic & ExpressJS errors
+  console.error(err);
+  res.status(500).json({ err: err.toString() });
+});
+
+app.listen(port, () => {
+  console.log(`Search Microservice exposed on port: ${port}`);
+});

--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -96,12 +96,24 @@ app.get("/search/:domain", async (req, res) => {
   res.status(200).json({ results: result });
 });
 
+app.get("/", async (req, res) => {
+  res.sendFile(path.join(__dirname, "resources/index.html"));
+});
+
 app.get("/problems/unsupported-domain", async (req, res) => {
   res.sendFile(path.join(__dirname, "resources/problems/unsupported-domain.html"));
 });
 
 app.get("/problems/unknown-data-stream", async (req, res) => {
   res.sendFile(path.join(__dirname, "resources/problems/unknown-data-stream.html"));
+});
+
+app.get("/robots.txt", async (req, res) => {
+  res.sendFile(path.join(__dirname, "resources/robots.txt"));
+});
+
+app.get("/sitemap.xml", async (req, res) => {
+  res.sendFile(path.join(__dirname, "resources/sitemap.xml"));
 });
 
 app.use(async (req, res) => {

--- a/microservices/search/package-lock.json
+++ b/microservices/search/package-lock.json
@@ -1,0 +1,837 @@
+{
+  "name": "search-microservice",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "search-microservice",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "express": "^5.2.1",
+        "lunr": "^2.3.9"
+      },
+      "engines": {
+        "node": ">=16.16.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/microservices/search/package.json
+++ b/microservices/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-microservice",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "Microservice to search Pulsar resources.",
   "main": "index.js",
   "scripts": {

--- a/microservices/search/package.json
+++ b/microservices/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-microservice",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Microservice to search Pulsar resources.",
   "main": "index.js",
   "scripts": {

--- a/microservices/search/package.json
+++ b/microservices/search/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "search-microservice",
+  "version": "1.0.0",
+  "description": "Microservice to search Pulsar resources.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node ./index.js"
+  },
+  "engines": {
+    "node": ">=16.16.0"
+  },
+  "author": "confused-Techie",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^5.2.1",
+    "lunr": "^2.3.9"
+  }
+}

--- a/microservices/search/policy.yaml
+++ b/microservices/search/policy.yaml
@@ -1,0 +1,4 @@
+bindings:
+  - members:
+    - allUsers
+    role: roles/run.invoker

--- a/microservices/search/resources/index.html
+++ b/microservices/search/resources/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <title>Pulsar Search</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta id="meta-scheme" name="color-scheme" content="light">
+    <link rel="stylesheet" href="https://docs.pulsar-edit.dev/main.css">
+    <script type="text/javascript">
+      {
+        let theme = (window.matchMedia("(prefers-color-scheme: light)").matches) ? "light" : "dark";
+        document.getElementById("meta-scheme").setAttribute("content", theme);
+        document.documentElement.dataset.theme = theme;
+      }
+    </script>
+  </head>
+  <body data-layout="summary">
+    <div class="content">
+      <main class="container">
+        <section class="header">
+          <h1 id="title" class="title">Pulsar Search</h1>
+        </section>
+        <p>
+          Welcome to the Pulsar Search Microservice, allowing easy search capabilities for
+          our different domains. Please refer to our <a href="https://docs.pulsar-edit.dev">docs</a>
+          for usage.
+        </p>
+      </main>
+    </div>
+  </body>
+</html>

--- a/microservices/search/resources/problems/unknown-data-stream.html
+++ b/microservices/search/resources/problems/unknown-data-stream.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
   <head>
-    <title>Problem | Unsupported Domain</title>
+    <title>Problem | Unknown Data Stream</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta id="meta-scheme" name="color-scheme" content="light">
     <link rel="stylesheet" href="https://docs.pulsar-edit.dev/main.css">

--- a/microservices/search/resources/problems/unknown-data-stream.html
+++ b/microservices/search/resources/problems/unknown-data-stream.html
@@ -1,7 +1,17 @@
 <!DOCTYPE html>
-<html>
+<html lang="en" data-theme="light">
   <head>
-    <title>Unsupported Domain</title>
+    <title>Problem | Unsupported Domain</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta id="meta-scheme" name="color-scheme" content="light">
+    <link rel="stylesheet" href="https://docs.pulsar-edit.dev/main.css">
+    <script type="text/javascript">
+      {
+        let theme = (window.matchMedia("(prefers-color-scheme: light)").matches) ? "light" : "dark";
+        document.getElementById("meta-scheme").setAttribute("content", theme);
+        document.documentElement.dataset.theme = theme;
+      }
+    </script>
   </head>
   <body>
     <b>Type URI:</b> https://search.pulsar-edit.dev/problems/unknown-data-stream

--- a/microservices/search/resources/problems/unknown-data-stream.html
+++ b/microservices/search/resources/problems/unknown-data-stream.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Unsupported Domain</title>
+  </head>
+  <body>
+    <b>Type URI:</b> https://search.pulsar-edit.dev/problems/unknown-data-stream
+    <br>
+    <b>Title:</b> The data stream location couldn't be identified.
+    <br>
+    <b>Recommended HTTP status Code:</b> <code>500</code>
+    <br>
+    <b>Reference:</b> RFC 9457
+    <br>
+    <b>Details:</b> When attempting to re-index a domain the search microservice
+      was unable to identify or collect the `search-index` document.
+      Please report this issue to the Pulsar developers.
+  </body>
+</html>

--- a/microservices/search/resources/problems/unsupported-domain.html
+++ b/microservices/search/resources/problems/unsupported-domain.html
@@ -9,7 +9,6 @@
       {
         let theme = (window.matchMedia("(prefers-color-scheme: light)").matches) ? "light" : "dark";
         document.getElementById("meta-scheme").setAttribute("content", theme);
-        document.documentElement.dataset.themeSetting = theme;
         document.documentElement.dataset.theme = theme;
       }
     </script>

--- a/microservices/search/resources/problems/unsupported-domain.html
+++ b/microservices/search/resources/problems/unsupported-domain.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Unsupported Domain</title>
+  </head>
+  <body>
+    <b>Type URI:</b> https://search.pulsar-edit.dev/problems/unsupported-domain
+    <br>
+    <b>Title:</b> The Domain provided is not supported.
+    <br>
+    <b>Recommended HTTP status Code:</b> <code>400</code>
+    <br>
+    <b>Reference:</b> RFC 9457
+    <br>
+    <b>Details:</b> The Pulsar search service only supports specific Pulsar subdomains,
+      as defined in `https://github.com/pulsar-edit/package-frontend`/`microservices/search/index.js`.
+      If the provided domain is not supported there it will not work in search until it is.
+  </body>
+</html>

--- a/microservices/search/resources/problems/unsupported-domain.html
+++ b/microservices/search/resources/problems/unsupported-domain.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en" data-theme="light">
   <head>
-    <title>Unsupported Domain</title>
+    <title>Problem | Unsupported Domain</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta id="meta-scheme" name="color-scheme" content="light">
+    <link rel="stylesheet" href="https://docs.pulsar-edit.dev/main.css">
+    <script type="text/javascript">
+      {
+        let theme = (window.matchMedia("(prefers-color-scheme: light)").matches) ? "light" : "dark";
+        document.getElementById("meta-scheme").setAttribute("content", theme);
+        document.documentElement.dataset.themeSetting = theme;
+        document.documentElement.dataset.theme = theme;
+      }
+    </script>
   </head>
   <body>
     <b>Type URI:</b> https://search.pulsar-edit.dev/problems/unsupported-domain

--- a/microservices/search/resources/robots.txt
+++ b/microservices/search/resources/robots.txt
@@ -1,3 +1,4 @@
 Sitemap: https://search.pulsar-edit.dev/sitemap.xml
 User-agent: *
 Allow: /
+Disallow: /reindex

--- a/microservices/search/resources/robots.txt
+++ b/microservices/search/resources/robots.txt
@@ -1,0 +1,3 @@
+Sitemap: https://search.pulsar-edit.dev/sitemap.xml
+User-agent: *
+Allow: /

--- a/microservices/search/resources/sitemap.xml
+++ b/microservices/search/resources/sitemap.xml
@@ -1,0 +1,23 @@
+<urlset>
+  <url>
+    <loc>
+      https://search.pulsar-edit.dev/
+    </loc>
+    <lastmod>2026-02-09T00:00:00.000Z</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>
+      https://search.pulsar-edit.dev/problems/unknown-data-stream
+    </loc>
+    <lastmod>2026-02-09T00:00:00.000Z</lastmod>
+    <changefreq>yearly</changefreq>
+  </url>
+  <url>
+    <loc>
+      https://search.pulsar-edit.dev/problems/unsupported-domain
+    </loc>
+    <lastmod>2026-02-09T00:00:00.000Z</lastmod>
+    <changefreq>yearly</changefreq>
+  </url>
+</urlset>

--- a/microservices/search/search.js
+++ b/microservices/search/search.js
@@ -8,7 +8,7 @@ class Search {
     this.index; // The in-memory index from lunr
     this.isLoaded = false; // If the search index is currently loaded
     this.dirty = false; // If our working index is different from the one on disk
-    this.devEnv = true; // If we are in a dev environment
+    this.devEnv = false; // If we are in a dev environment
   }
 
   // Create a new index
@@ -16,7 +16,7 @@ class Search {
     const readline = require("node:readline");
 
     let stream;
-    if (this.devEnv && false) {
+    if (this.devEnv) {
       stream = fs.createReadStream("./search-index.jsonl");
     } else {
       const https = require("node:https");

--- a/microservices/search/search.js
+++ b/microservices/search/search.js
@@ -75,7 +75,7 @@ class Search {
       return;
     }
     // Load index from disk
-    const file = fs.readFileSync(`./${this.domain}.index.json`, { encoding: "utf8" });
+    const file = fs.readFileSync(`./mnt/${this.domain}.index.json`, { encoding: "utf8" });
     this.index = lunr.Index.load(JSON.parse(file));
   }
 
@@ -83,7 +83,7 @@ class Search {
   save() {
     if (this.dirty) {
       // Only save when we have a different copy of the index in memory than on disk
-      fs.writeFileSync(`./${this.domain}.index.json`, JSON.stringify(this.index), { encoding: "utf8" });
+      fs.writeFileSync(`./mnt/${this.domain}.index.json`, JSON.stringify(this.index), { encoding: "utf8" });
     }
   }
 

--- a/microservices/search/search.js
+++ b/microservices/search/search.js
@@ -1,0 +1,103 @@
+const fs = require("node:fs");
+const lunr = require("lunr");
+
+module.exports =
+class Search {
+  constructor(domain) {
+    this.domain = domain; // The domain this search is for
+    this.index; // The in-memory index from lunr
+    this.isLoaded = false; // If the search index is currently loaded
+    this.dirty = false; // If our working index is different from the one on disk
+    this.devEnv = true; // If we are in a dev environment
+  }
+
+  // Create a new index
+  async reindex() {
+    const readline = require("node:readline");
+
+    let stream;
+    if (this.devEnv && false) {
+      stream = fs.createReadStream("./search-index.jsonl");
+    } else {
+      const https = require("node:https");
+      const assignStream = async () => {
+        return new Promise((resolve) => {
+          https.get(`https://${this.domain}/search-index.jsonl`, (res) => {
+            resolve(res);
+          }).on("error", (err) => {
+            throw err;
+          });
+        });
+      };
+
+      stream = await assignStream();
+    }
+
+    if (!stream) {
+      // Failed to create a readable stream
+      throw new Error("The data stream is undefined!");
+    }
+
+    const rl = readline.createInterface({
+      input: stream,
+      crlfDelay: Infinity
+    });
+
+    const documents = [];
+
+    rl.on("line", (line) => {
+      documents.push(JSON.parse(line));
+    });
+
+    rl.on("close", () => {
+      // Once we've read the entire stream, we can create our new index
+      this.index = lunr(function () {
+        this.ref("url");
+        this.field("title");
+        this.field("body");
+        this.metadataWhitelist = ["position"];
+
+        documents.forEach(function (doc) {
+          this.add(doc);
+        }, this);
+      });
+
+      this.isLoaded = true;
+      this.dirty = true;
+    });
+  }
+
+  // Load a search index for this domain
+  load() {
+    if (this.isLoaded) {
+      // We've already loaded an index, we don't need to do it again.
+      return;
+    }
+    // Load index from disk
+    const file = fs.readFileSync(`./${this.domain}.index.json`, { encoding: "utf8" });
+    this.index = lunr.Index.load(JSON.parse(file));
+  }
+
+  // Save the search engine for this domain to disk
+  save() {
+    if (this.dirty) {
+      // Only save when we have a different copy of the index in memory than on disk
+      fs.writeFileSync(`./${this.domain}.index.json`, JSON.stringify(this.index), { encoding: "utf8" });
+    }
+  }
+
+  // Search the index
+  search(query) {
+    if (!query) {
+      // We didn't get anything to search with, lets return empty results
+      return [];
+    }
+
+    if (!this.isLoaded) {
+      // Our index isn't loaded, lets load it first
+      this.load();
+    }
+
+    return this.index.search(query);
+  }
+}

--- a/microservices/search/search.js
+++ b/microservices/search/search.js
@@ -9,6 +9,7 @@ class Search {
     this.isLoaded = false; // If the search index is currently loaded
     this.dirty = false; // If our working index is different from the one on disk
     this.devEnv = false; // If we are in a dev environment
+    this.devFileIndex = "./search-index.jsonl";
   }
 
   // Create a new index
@@ -17,7 +18,7 @@ class Search {
 
     let stream;
     if (this.devEnv) {
-      stream = fs.createReadStream("./search-index.jsonl");
+      stream = fs.createReadStream(this.devFileIndex);
     } else {
       const https = require("node:https");
       const assignStream = async () => {

--- a/microservices/search/service.yaml
+++ b/microservices/search/service.yaml
@@ -9,7 +9,7 @@ spec:
         run.googleapis.com/execution-environment: gen2
     spec:
       containers:
-      - image: us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.1
+      - image: us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.4
         volumeMounts:
         - name: GCS
           mountPath: /usr/src/app/mnt

--- a/microservices/search/service.yaml
+++ b/microservices/search/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: search
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/execution-environment: gen2
+    spec:
+      serviceAccountName: frontend-search@pulsar-357404.iam.gserviceaccount.com
+      containers:
+        - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.0"
+          volumeMounts:
+          - name: GCS
+            mountPath: /usr/src/app
+        volumes:
+        - name: GCS
+          csi:
+            driver: gcsfuse.run.googleapis.com
+            readOnly: False
+            volumeAttributes:
+              bucketName: "pulsar-search-microservice"

--- a/microservices/search/service.yaml
+++ b/microservices/search/service.yaml
@@ -8,16 +8,15 @@ spec:
       annotations:
         run.googleapis.com/execution-environment: gen2
     spec:
-      serviceAccountName: frontend-search@pulsar-357404.iam.gserviceaccount.com
       containers:
-        - image: "us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.0"
-          volumeMounts:
-          - name: GCS
-            mountPath: /usr/src/app
-        volumes:
+      - image: us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.1
+        volumeMounts:
         - name: GCS
-          csi:
-            driver: gcsfuse.run.googleapis.com
-            readOnly: False
-            volumeAttributes:
-              bucketName: "pulsar-search-microservice"
+          mountPath: /usr/src/app/mnt
+      volumes:
+      - name: GCS
+        csi:
+          driver: gcsfuse.run.googleapis.com
+          readOnly: False
+          volumeAttributes:
+            bucketName: pulsar-search-microservice


### PR DESCRIPTION
Relates to: [`pulsar-edit/documentation#40`](https://github.com/pulsar-edit/documentation/pull/40)

This PR introduces a new `search` microservice, which allows our static websites to implement full featured, full text search rather simply.

When a static site generates a `search-index.jsonl` file, it only needs to query this microservice to rebuild it's index of the site using that document. Which is then accessible via `GET https://search.pulsar-edit.dev/search/:domain?q=` to preform any searches against the entire site.

Also, since we are using [lunr](https://lunrjs.com/) for searching capabilities, we get to utilize all the advanced [searching](https://lunrjs.com/guides/searching.html) techniques they support.