### PR TITLE
Add CORS to `search`

### DIFF
--- a/microservices/search/index.js
+++ b/microservices/search/index.js
@@ -1,5 +1,6 @@
 const path = require("node:path");
 const express = require("express");
+const server_version = require("./package.json").version;
 const Search = require("./search.js");
 
 const app = express();
@@ -10,6 +11,13 @@ const DOMAIN_MAP = {
   "blog": "blog.pulsar-edit.dev"
 };
 const INDEXES = {}; // Instances of the search class w/ domain as the key
+
+app.use((req, res, next) => {
+  res.append("Server", `Pulsar Search Microservice/${server_version} (${process.platform})`);
+  res.append("Access-Control-Allow-Methods", "GET");
+
+  next();
+});
 
 app.post("/reindex/:domain", async (req, res) => {
   // Endpoint to trigger a re-index of content for a given sub-domain
@@ -69,6 +77,10 @@ app.get("/search/:domain", async (req, res) => {
     });
     return;
   }
+
+  // Add the Access-Control-Allow-Origin for the specific origin we received
+  // a request from
+  res.append("Access-Control-Allow-Origin", `https://${domain}`);
 
   if (!INDEXES[domain]) {
     // We don't have the search index for this domain loaded yet

--- a/microservices/search/package.json
+++ b/microservices/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-microservice",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Microservice to search Pulsar resources.",
   "main": "index.js",
   "scripts": {

--- a/microservices/search/service.yaml
+++ b/microservices/search/service.yaml
@@ -9,7 +9,7 @@ spec:
         run.googleapis.com/execution-environment: gen2
     spec:
       containers:
-      - image: us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.4
+      - image: us-west2-docker.pkg.dev/pulsar-357404/package-frontend/search:1.0.5
         volumeMounts:
         - name: GCS
           mountPath: /usr/src/app/mnt


### PR DESCRIPTION
This PR adds the required CORs configuration to the microservice, prior to launching the search ability on the docs website