### PR TITLE
Fix service list padding

### DIFF
--- a/site/templates/package_page.ejs
+++ b/site/templates/package_page.ejs
@@ -4,9 +4,7 @@
   <section class="header header--package-single">
     <div class="block block--package block--package-single">
       <header class="block__header">
-        <!-- <h1 class="title" id="title"> -->
         <a href="/packages/<%=pack.name%>"><%= pack.name %></a>
-        <!-- </h1> -->
       </header>
       <div class="block__summary">
         <%= pack.description %>
@@ -61,28 +59,12 @@
           <div class="sidebar__section-content service-section">
             <% if (helpers.hasServices(pack, 'provided')) { %>
               <p class="service-section__description">This package <em>provides</em>:</p>
-              <ul class="service-section__list">
-                <% for (let service in pack.providedServices) { %>
-                <li class="service-section__list-item">
-                  <a class="service-section__list-item-link" href="/packages?serviceType=consumed&service=<%=service%>">
-                    <%=service%>@<%=Object.keys(pack.providedServices[service].versions).join(', ')%>
-                  </a>
-                </li>
-                <% } %>
-              </ul>
+              <%- include("service_list", { services: pack.providedServices, oppositeServiceType: 'consumed' }) %>
             <% } %>
 
             <% if (helpers.hasServices(pack, 'consumed')) { %>
               <p class="service-section__description">This package <em>consumes</em>:</p>
-              <ul class="service-section__list">
-                <% for (let service in pack.consumedServices) { %>
-                <li class="service-list__item">
-                  <a class="service-list__item-link" href="/packages?serviceType=provided&service=<%=service%>">
-                    <%= service %>@<%=Object.keys(pack.consumedServices[service].versions).join(', ')%>
-                  </a>
-                </li>
-                <% } %>
-              </ul>
+              <%- include("service_list", { services: pack.consumedServices, oppositeServiceType: 'provided' }) %>
             <% } %>
           </div>
         </div>

--- a/site/templates/service_list.ejs
+++ b/site/templates/service_list.ejs
@@ -1,0 +1,10 @@
+
+<ul class="service-section__list">
+  <% for (let service in locals.services) { %>
+  <li class="service-section__list-item">
+    <a class="service-section__list-item-link" href="/packages?serviceType=<%= oppositeServiceType %>&service=<%= service %>">
+      <%= service %>@<%= Object.keys(services[service].versions).join(', ') %>
+    </a>
+  </li>
+  <% } %>
+</ul>


### PR DESCRIPTION
Visit the page of a package that both consumes and provides services ([like this one](https://packages.pulsar-edit.dev/packages/pulsar-hover)). Notice how the second list has different spacing than the first?

<p><img width="199" height="231" alt="Screenshot 2026-05-22 at 8 33 06 PM" src="https://github.com/user-attachments/assets/99f3c160-dd93-4305-9b0a-621dfa1377d7" /></p>

Not intentional! Probably changed a class name in one place but not the second. So I also took this opportunity to reduce repetition via a new template.

After merging it’ll look like this:

<p><img width="207" height="235" alt="Screenshot 2026-05-22 at 8 33 11 PM" src="https://github.com/user-attachments/assets/7b4dd021-5739-4dce-93df-0706c268a1f5" /></p>