### PR TITLE
Restyle advanced search to take up less space

### DIFF
--- a/site/resources-generated/search.less
+++ b/site/resources-generated/search.less
@@ -62,6 +62,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: .5rem;
 
   &__input {
     width: 66.6%;
@@ -101,11 +102,105 @@ form#search {
   }
 }
 
+.radio-pill {
+  display: inline-block;
+  position: relative;
+  margin: 0;
+
+  input, label {
+    margin: 0 !important;
+    display: inline-block;
+    cursor: pointer;
+  }
+
+  input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background: none;
+    border: 2px solid;
+    height: 100%;
+    left: 0;
+    opacity: .00001;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+  }
+
+  input[type="radio"]:focus-visible + label {
+    box-shadow: 0 0 0 1.5px var(--input-field-border-focus);
+  }
+
+  input:checked + label {
+    background: var(--btn-bg-primary);
+    color: var(--btn-color-primary);
+  }
+
+  label {
+    font-size: 13.5px;
+    border-radius: 2em;
+    border: 1px solid var(--thematic-break-color);
+    border-radius: 999px;
+    transition: all .12s;
+    white-space: nowrap;
+    display: block;
+    padding: .5rem 1rem !important;
+
+    &:after {
+      border: 2px solid;
+      border-color: rgba(0,0,0,0);
+      border-radius: 2em;
+      bottom: 0;
+      content: "";
+      left: 0;
+      pointer-events: none; /* 1 */
+      position: absolute;
+      right: 0;
+      top: 0;
+      transition:
+      bottom .2s ease-in-out,
+      border-color .2s ease-in-out,
+      left .2s ease-in-out,
+      right .2s ease-in-out,
+      top .2s ease-in-out;
+    }
+  }
+}
+
+.radio-group {
+  --border-radius: 1rem;
+  gap: 0 !important;
+
+  li {
+    .radio-pill();
+  }
+
+  li label {
+    border-radius: 0;
+  }
+
+  li:first-of-type label {
+    border-top-left-radius: var(--border-radius);
+    border-bottom-left-radius: var(--border-radius);
+  }
+
+  li:last-of-type label {
+    border-left-width: 0;
+    border-top-right-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+  }
+
+  i.icon-arrow-down:before,
+  i.icon-arrow-up:before {
+    position: relative;
+    top: 1px;
+    width: 12px;
+  }
+}
+
 .as {
   padding: 1rem;
-  // border: 1px solid var(--thematic-break-color);
-  // box-shadow: 0 0 1px 1px var(--card-shadow-color);
-  // margin-bottom: 2rem;
 
   &__section-content--sort {
     display: flex;
@@ -137,7 +232,6 @@ form#search {
     min-width: 0;
     max-width: 100%;
     flex-basis: 1 1 30%;
-    // border-left: 0.25rem solid var(--thematic-break-color);
     overflow: clip;
   }
 
@@ -183,10 +277,6 @@ form#search {
     // flex-basis: 30%;
   }
 
-  input[type="radio"]:focus-visible + label {
-    box-shadow: 0 0 1px 3px var(--btn-bg-primary);
-  }
-
   aside {
     font-size: 12px;
     margin: 0.25rem 0;
@@ -205,135 +295,9 @@ form#search {
     padding: 6px 0;
   }
 
-  &__list--sort {
-    li:has(input[type="radio"]) {
-      display: inline-block;
-      position: relative;
-      margin: 0;
-      // padding: 0;
-      // display: flex;
-      // flex-direction: row;
-      // align-items: center;
-      // gap: 0.5rem;
-
-      input:checked + label {
-        background: var(--btn-bg-primary);
-        color: var(--btn-color-primary);
-      }
-
-      input, label {
-        margin: 0 !important;
-        display: inline-block;
-      }
-
-      input {
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        appearance: none;
-        background: none;
-        border: 2px solid;
-        height: 100%;
-        left: 0;
-        opacity: .00001;
-        position: absolute;
-        top: 0;
-        width: 100%;
-        z-index: 2;
-      }
-
-      label {
-        font-size: 13.5px;
-        border-radius: 2em;
-        border: 1px solid var(--thematic-break-color);
-        border-radius: 999px;
-        transition: all .12s;
-        white-space: nowrap;
-        display: block;
-        padding: .5rem 1rem;
-
-        &:after {
-          border: 2px solid;
-          border-color: rgba(0,0,0,0);
-          border-radius: 2em;
-          bottom: 0;
-          content: "";
-          left: 0;
-          pointer-events: none; /* 1 */
-          position: absolute;
-          right: 0;
-          top: 0;
-          transition:
-          bottom .2s ease-in-out,
-          border-color .2s ease-in-out,
-          left .2s ease-in-out,
-          right .2s ease-in-out,
-          top .2s ease-in-out;
-        }
-      }
-    }
-  }
-
   &__list--direction {
     display: flex;
     flex-direction: row;
-    gap: 0 !important;
-
-    li {
-      position: relative;
-      margin: 0;
-
-      &:first-of-type label {
-        border-top-left-radius: 1rem;
-        border-bottom-left-radius: 1rem;
-      }
-
-      &:last-of-type label {
-        border-left-width: 0;
-        border-top-right-radius: 1rem;
-        border-bottom-right-radius: 1rem;
-      }
-
-      label {
-        display: block;
-
-        .icon::before {
-          text-align: center;
-        }
-      }
-    }
-
-    input:checked + label {
-      background: var(--btn-bg-primary);
-      color: var(--btn-color-primary);
-    }
-
-    input, label {
-      margin: 0 !important;
-      display: inline-block;
-    }
-
-    input {
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
-      background: none;
-      border: 2px solid;
-      height: 100%;
-      left: 0;
-      opacity: .00001;
-      position: absolute;
-      top: 0;
-      width: 100%;
-      z-index: 2;
-    }
-
-    label {
-      padding: .5rem 1rem;
-      border: 1px solid var(--thematic-break-color);
-      transition: all .12s;
-      white-space: nowrap;
-      display: block;
-    }
   }
 
   &__list {

--- a/site/resources-generated/search.less
+++ b/site/resources-generated/search.less
@@ -8,6 +8,53 @@
 
   &__advanced-search {
     margin-top: 1rem;
+    margin-bottom: 1rem;
+    border-radius: 12px;
+    border: .25rem solid transparent;
+    padding: 0 .5rem;
+
+    summary {
+      cursor: pointer;
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      padding: 1rem;
+
+      aside {
+        font-size: 13px;
+        font-style: italic;
+        align-self: center;
+        display: none;
+      }
+    }
+
+    summary + div {
+      padding-bottom: 1.5rem;
+    }
+
+    &[open] {
+      border-color: var(--thematic-break-color);
+
+      summary aside {
+        display: block;
+      }
+
+      .search-area__advanced-search-title {
+        transform: translateX(0);
+        &:before {
+          content: '▼';
+        }
+      }
+    }
+  }
+
+  &__advanced-search-title {
+    transition: transform 0.2s;
+    transform: translateX(-1.5rem);
+    &:before {
+      content: '▶';
+      padding-right: 0.5ch;
+    }
   }
 }
 
@@ -25,7 +72,7 @@
 }
 
 search {
-  max-width: 60vw;
+  max-width: 80vw;
   margin: 0 auto;
 }
 
@@ -34,7 +81,7 @@ option[disabled] {
 }
 
 form#search {
-  max-width: 48rem;
+  // max-width: 48rem;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -55,8 +102,30 @@ form#search {
 }
 
 .as {
-  padding: 1rem 0;
-  margin-bottom: 2rem;
+  padding: 1rem;
+  // border: 1px solid var(--thematic-break-color);
+  // box-shadow: 0 0 1px 1px var(--card-shadow-color);
+  // margin-bottom: 2rem;
+
+  &__section-content--sort {
+    display: flex;
+    flex-direction: row;
+    gap: 2rem;
+    padding-bottom: 2px;
+  }
+
+  &__row-wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: 1.5rem;
+    row-gap: .5rem;
+  }
+
+  &__row-wrapper--criteria {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
 
   &__header {
     margin: 0 0 1.5rem;
@@ -64,22 +133,58 @@ form#search {
 
   &__section {
     margin: 0 0 1.5rem;
+    padding: 0.25rem 0 0.25rem 0;
+    min-width: 0;
+    max-width: 100%;
+    flex-basis: 1 1 30%;
+    // border-left: 0.25rem solid var(--thematic-break-color);
+    overflow: clip;
+  }
+
+  &__section--service {
+    grid-column: 1 / -1;
+
+    .as__section-subcontent {
+
+      label, input, select {
+        margin: 0;
+      }
+
+      & > div {
+        display: flex;
+        flex-direction: column;
+      }
+    }
+  }
+
+  &__section-subcontent--service {
+    row-gap: .5rem;
   }
 
   &__section-header {
     text-transform: uppercase;
     font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 1px;
     margin: 0 0 0.5rem;
   }
 
   &__section-content {
-    padding-left: 1rem;
-    border-left: 0.25rem solid var(--thematic-break-color);
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
   }
 
   &__section-subcontent {
     display: grid;
     grid: auto-flow / 1fr;
+    width: 100%;
+    row-gap: .5rem;
+    // flex-basis: 30%;
+  }
+
+  input[type="radio"]:focus-visible + label {
+    box-shadow: 0 0 1px 3px var(--btn-bg-primary);
   }
 
   aside {
@@ -87,35 +192,173 @@ form#search {
     margin: 0.25rem 0;
   }
 
+  input {
+    min-width: 0;
+    margin-bottom: 0;
+  }
+
   label {
     font-weight: 500;
+    font-size: 14px;
     // Add some padding to labels so that they appear visually aligned with
     // their input/select fields.
     padding: 6px 0;
   }
 
-  &__list {
-    margin: 0 !important;
-    list-style-type: none;
-
-    li {
+  &__list--sort {
+    li:has(input[type="radio"]) {
+      display: inline-block;
+      position: relative;
       margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      gap: 0.5rem;
+      // padding: 0;
+      // display: flex;
+      // flex-direction: row;
+      // align-items: center;
+      // gap: 0.5rem;
+
+      input:checked + label {
+        background: var(--btn-bg-primary);
+        color: var(--btn-color-primary);
+      }
 
       input, label {
         margin: 0 !important;
+        display: inline-block;
       }
+
+      input {
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        background: none;
+        border: 2px solid;
+        height: 100%;
+        left: 0;
+        opacity: .00001;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        z-index: 2;
+      }
+
+      label {
+        font-size: 13.5px;
+        border-radius: 2em;
+        border: 1px solid var(--thematic-break-color);
+        border-radius: 999px;
+        transition: all .12s;
+        white-space: nowrap;
+        display: block;
+        padding: .5rem 1rem;
+
+        &:after {
+          border: 2px solid;
+          border-color: rgba(0,0,0,0);
+          border-radius: 2em;
+          bottom: 0;
+          content: "";
+          left: 0;
+          pointer-events: none; /* 1 */
+          position: absolute;
+          right: 0;
+          top: 0;
+          transition:
+          bottom .2s ease-in-out,
+          border-color .2s ease-in-out,
+          left .2s ease-in-out,
+          right .2s ease-in-out,
+          top .2s ease-in-out;
+        }
+      }
+    }
+  }
+
+  &__list--direction {
+    display: flex;
+    flex-direction: row;
+    gap: 0 !important;
+
+    li {
+      position: relative;
+      margin: 0;
+
+      &:first-of-type label {
+        border-top-left-radius: 1rem;
+        border-bottom-left-radius: 1rem;
+      }
+
+      &:last-of-type label {
+        border-left-width: 0;
+        border-top-right-radius: 1rem;
+        border-bottom-right-radius: 1rem;
+      }
+
+      label {
+        display: block;
+
+        .icon::before {
+          text-align: center;
+        }
+      }
+    }
+
+    input:checked + label {
+      background: var(--btn-bg-primary);
+      color: var(--btn-color-primary);
+    }
+
+    input, label {
+      margin: 0 !important;
+      display: inline-block;
+    }
+
+    input {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      background: none;
+      border: 2px solid;
+      height: 100%;
+      left: 0;
+      opacity: .00001;
+      position: absolute;
+      top: 0;
+      width: 100%;
+      z-index: 2;
+    }
+
+    label {
+      padding: .5rem 1rem;
+      border: 1px solid var(--thematic-break-color);
+      transition: all .12s;
+      white-space: nowrap;
+      display: block;
+    }
+  }
+
+  &__list {
+    margin: 0 !important;
+    list-style-type: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+  }
+}
+
+@media (min-width: @bp-larger-than-phablet) {
+  .as {
+    &__row-wrapper--criteria {
+      grid-template-columns: repeat(2, 1fr);
     }
   }
 }
 
-
 @media (min-width: @bp-larger-than-tablet) {
   .as {
+    &__row-wrapper--criteria {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
     &__list {
       display: flex;
       flex-direction: row;
@@ -123,11 +366,21 @@ form#search {
     }
 
     &__section-subcontent {
-      grid: auto-flow / 150px 1fr;
-      gap: 1rem;
+      // grid: auto-flow / 150px 1fr;
+      // gap: 1rem;
 
-      label, input, select {
-        margin: 0;
+      input, select {
+        width: 100%;
+      }
+    }
+
+    &__section-subcontent--service {
+      grid-template-columns: repeat(3, 1fr);
+      row-gap: 0;
+      column-gap: .5rem;
+
+      & > div {
+        flex-direction: column;
       }
     }
   }
@@ -135,5 +388,6 @@ form#search {
 
 select.empty {
   color: inherit;
-  opacity: 0.5;
+  color: #ccc;
+  // opacity: 0.5;
 }

--- a/site/resources-generated/site.js
+++ b/site/resources-generated/site.js
@@ -216,6 +216,19 @@ const AccountActions = {
     }
   });
 
+
+  const serviceSearchType = document.getElementById('service-type');
+  function handleServiceSelectClassName () {
+    if (!serviceSearchType) return;
+    if (serviceSearchType.value === '') {
+      serviceSearchType.classList.add('empty');
+    } else {
+      serviceSearchType.classList.remove('empty');
+    }
+  }
+  serviceSearchType?.addEventListener('change', handleServiceSelectClassName);
+  handleServiceSelectClassName();
+
   let url = new URL(location.toString());
 
   window.addEventListener('pageshow', () => {

--- a/site/templates/advanced_search.ejs
+++ b/site/templates/advanced_search.ejs
@@ -1,98 +1,118 @@
-<section class="as">
-  <header class="as__header">All fields are <strong>optional</strong>.</header>
+<details class="search-area__advanced-search">
+  <summary class="search-area__advanced-search-summary">
+    <span class="search-area__advanced-search-title">Advanced search</span>
+    <aside>All fields are optional</aside>
+  </summary>
 
-  <section class="as__section">
-    <header class="as__section-header">Sort by</header>
-    <div class="as__section-content">
-      <ul class="as__list">
-        <li>
-          <%#
-            `data-skip-expand` is on this radio button because it's the default
-            value. Unless other values in advanced search are also present, we
-            don't want the presence of `sort=downloads` in the URL to trigger
-            the expansion of this advanced search area.
-          %>
-          <input type="radio" name="sort" id="sort-downloads" value="downloads" data-skip-expand checked>
-          <label for="sort-downloads">Downloads</label>
-        </li>
-        <li>
-          <input type="radio" name="sort" id="sort-created" value="created_at">
-          <label for="sort-created">Created</label>
-        </li>
-        <li>
-          <input type="radio" name="sort" id="sort-updated" value="updated_at">
-          <label for="sort-updated">Updated</label>
-        </li>
-        <li>
-          <input type="radio" name="sort" id="sort-stars" value="stars">
-          <label for="sort-stars">Stars</label>
-        </li>
-        <li>
-          <input type="radio" name="sort" id="sort-relevance" value="relevance">
-          <label for="sort-relevance">Relevance</label>
-        </li>
-      </ul>
-      <div>
-        <select name="direction" id="direction" data-skip-expand>
-          <option value="desc" checked>descending</option>
-          <option value="asc">ascending</option>
-        </select>
-      </div>
-    </div>
-  </section>
+  <section class="as">
 
-  <section class="as__section">
-    <header class="as__section-header">Grammar</header>
-    <div class="as__section-content">
-      <div class="as__section-subcontent">
-        <label for="file-extension">File extension…</label>
-        <div>
-          <input type="text" name="fileExtension" id="file-extension">
-          <aside>Find all packages that provide syntax highlighting for files of the given extension.</aside>
+    <div class="as__row-wrapper">
+      <section class="as__section">
+        <header class="as__section-header">Sort by</header>
+        <div class="as__section-content as__section-content--sort">
+          <ul class="as__list as__list--sort">
+            <li>
+              <%#
+                `data-skip-expand` is on this radio button because it's the default
+                value. Unless other values in advanced search are also present, we
+                don't want the presence of `sort=downloads` in the URL to trigger
+                the expansion of this advanced search area.
+              %>
+              <input type="radio" name="sort" id="sort-downloads" value="downloads" data-skip-expand checked>
+              <label for="sort-downloads">Downloads</label>
+            </li>
+            <li>
+              <input type="radio" name="sort" id="sort-created" value="created_at">
+              <label for="sort-created">Created</label>
+            </li>
+            <li>
+              <input type="radio" name="sort" id="sort-updated" value="updated_at">
+              <label for="sort-updated">Updated</label>
+            </li>
+            <li>
+              <input type="radio" name="sort" id="sort-stars" value="stars">
+              <label for="sort-stars">Stars</label>
+            </li>
+            <li>
+              <input type="radio" name="sort" id="sort-relevance" value="relevance">
+              <label for="sort-relevance">Relevance</label>
+            </li>
+          </ul>
+
+          <ul class="as__list as__list--direction">
+            <li>
+              <input type="radio" name="direction" id="direction-desc" value="desc">
+              <label for="direction-desc">
+                <i class="icon icon-arrow-down"></i>
+                Descending
+              </label>
+            </li>
+            <li>
+              <input type="radio" name="direction" id="direction-asc" value="asc">
+              <label for="direction-asc">
+                <i class="icon icon-arrow-up"></i>
+                Ascending
+              </label>
+            </li>
+          </ul>
         </div>
-      </div>
+      </section>
     </div>
-  </section>
 
-  <section class="as__section">
-    <header class="as__section-header">Service</header>
-    <div class="as__section-content">
-      <div class="as__section-subcontent">
-        <label for="service-type">Find a…</label>
-        <select name="serviceType" id="service-type" data-skip-expand>
-          <option value=""></option>
-          <option value="provided">provider</option>
-          <option value="consumed">consumer</option>
-        </select>
-        <label for="service-name">of a service called…</label>
-        <div>
-          <input
-            type="text"
-            name="service"
-            id="service-name"
-            placeholder="e.g., autocomplete.provider">
+    <div class="as__row-wrapper as__row-wrapper--criteria">
+      <section class="as__section">
+        <header class="as__section-header">Grammar</header>
+        <div class="as__section-content">
+          <div class="as__section-subcontent">
+            <input type="text" name="fileExtension" id="file-extension" placeholder="File extension…" aria-label="File extension…" aria-describedby="file-extension-aside">
+            <aside id="file-extension-aside">Find all packages that provide syntax highlighting for files of the given extension.</aside>
+          </div>
         </div>
-        <label for="service-version">of version…</label>
-        <div>
-          <input
-            type="text"
-            name="serviceVersion"
-            id="service-version"
-            placeholder="e.g., 1.0.0">
-        </div>
-      </div>
-    </div>
-  </section>
+      </section>
 
-  <section class="as__section">
-    <header class="as__section-header">
-      Author
-    </header>
-    <div class="as__section-content">
-      <div class="as__section-subcontent">
-        <label for="owner">Published by…</label>
-        <input type="text" name="owner" id="owner">
-      </div>
+      <section class="as__section">
+        <header class="as__section-header">
+          Author
+        </header>
+        <div class="as__section-content">
+          <div class="as__section-subcontent">
+            <input type="text" name="owner" id="owner" placeholder="Published by…" aria-label="Published by…">
+          </div>
+        </div>
+      </section>
+
+      <section class="as__section as__section--service">
+        <header class="as__section-header">Service</header>
+        <div class="as__section-content">
+          <div class="as__section-subcontent as__section-subcontent--service">
+            <div>
+              <select name="serviceType" id="service-type" aria-label="Find a…" data-skip-expand>
+                <option value="" disabled>Find a…</option>
+                <option value="provided">provider</option>
+                <option value="consumed">consumer</option>
+              </select>
+            </div>
+            <div>
+                <input
+                  type="text"
+                  name="service"
+                  id="service-name"
+                  aria-label="of service…"
+                  placeholder="of service…">
+            </div>
+
+            <div>
+                <input
+                  type="text"
+                  name="serviceVersion"
+                  id="service-version"
+                  aria-label="of version…"
+                  placeholder="of version…">
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
+
   </section>
-</section>
+</details>

--- a/site/templates/advanced_search.ejs
+++ b/site/templates/advanced_search.ejs
@@ -11,7 +11,7 @@
         <header class="as__section-header">Sort by</header>
         <div class="as__section-content as__section-content--sort">
           <ul class="as__list as__list--sort">
-            <li>
+            <li class="radio-pill">
               <%#
                 `data-skip-expand` is on this radio button because it's the default
                 value. Unless other values in advanced search are also present, we
@@ -21,25 +21,25 @@
               <input type="radio" name="sort" id="sort-downloads" value="downloads" data-skip-expand checked>
               <label for="sort-downloads">Downloads</label>
             </li>
-            <li>
+            <li class="radio-pill">
               <input type="radio" name="sort" id="sort-created" value="created_at">
               <label for="sort-created">Created</label>
             </li>
-            <li>
+            <li class="radio-pill">
               <input type="radio" name="sort" id="sort-updated" value="updated_at">
               <label for="sort-updated">Updated</label>
             </li>
-            <li>
+            <li class="radio-pill">
               <input type="radio" name="sort" id="sort-stars" value="stars">
               <label for="sort-stars">Stars</label>
             </li>
-            <li>
+            <li class="radio-pill">
               <input type="radio" name="sort" id="sort-relevance" value="relevance">
               <label for="sort-relevance">Relevance</label>
             </li>
           </ul>
 
-          <ul class="as__list as__list--direction">
+          <ul class="as__list radio-group">
             <li>
               <input type="radio" name="direction" id="direction-desc" value="desc">
               <label for="direction-desc">

--- a/site/templates/search_bar.ejs
+++ b/site/templates/search_bar.ejs
@@ -17,12 +17,7 @@
       </div>
 
       <% if (locals.advanced_search) { %>
-        <details class="search-area__advanced-search">
-          <summary>Advanced search</summary>
-          <div>
-            <%- include("advanced_search") %>
-          </div>
-        </details>
+      <%- include("advanced_search") %>
       <% } %>
     </form>
   </search>


### PR DESCRIPTION
I built this UI a while back and I already don't like it:

<p><img width="585" height="726" alt="Screenshot 2026-06-04 at 11 15 01 PM" src="https://github.com/user-attachments/assets/2a397300-82f6-4815-bfd9-84832a31e610" /></p>

Elaborate forms are a pain to style in a responsive way, so I did the best I could at the time and shipped it.

But now it's hard to ignore how much of the page it takes up. So I played around with a few ideas for making it more compact and went with the one I dislike the least.

<p><img width="817" height="496" alt="Screenshot 2026-06-04 at 11 15 26 PM" src="https://github.com/user-attachments/assets/a332b0d1-1cca-4b18-9328-0feb8dfd4662" /></p>

The pill buttons are still radio buttons — just styled with some clever CSS that I got from somewhere. I did swap in placeholder text for labels, but atoned for the a11y sin by adding `aria-label` to all the `input`s.
