### PR TITLE
Make the search field expand to fill horizontal space

### DIFF
--- a/site/resources-generated/search.less
+++ b/site/resources-generated/search.less
@@ -65,8 +65,7 @@
   gap: .5rem;
 
   &__input {
-    width: 66.6%;
-    max-width: 48rem;
+    flex-grow: 1;
     padding-left: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
This was an unintentional by-product of #152:

<p><img width="1079" height="124" alt="Screenshot 2026-06-07 at 2 31 34 PM" src="https://github.com/user-attachments/assets/b3137311-d6ee-4848-922b-c99ec3022c31" /></p>

This PR fixes that by making the search field wider.